### PR TITLE
ensuring 335767902 is set when consent submitted

### DIFF
--- a/js/pages/consent.js
+++ b/js/pages/consent.js
@@ -1194,7 +1194,8 @@ const consentSubmit = async e => {
         formData['430184574'] = CSWDate.split('/')[2] + CSWDate.split('/')[1] + CSWDate.split('/')[0]
     }
     formData['507120821'] = 596523216;
-    const response = await storeResponse(formData);
     formData['335767902'] = new Date().toISOString();
+    
+    const response = await storeResponse(formData);
     if(response.code === 200) consentFinishedPage ();
 }


### PR DESCRIPTION
* CID 335767902 was being set on the consentSubmit() function within consent.js AFTER calling storeResponse()
* shifting around a few lines of code to make sure value is set before storing information to backend db