### PR TITLE
Change error message when creating a new email account

### DIFF
--- a/js/pages/homePage.js
+++ b/js/pages/homePage.js
@@ -394,6 +394,15 @@ export async function signInCheckRender ({ ui }) {
           .addEventListener('click', (e) => {
             signUpRender({ ui });
           });
+
+          document
+            .querySelector('button[class~="firebaseui-id-submit"]')
+            .addEventListener('click', (e) => {
+              const pEle = document.querySelector('p[class~="firebaseui-text-input-error"]');
+              if (pEle?.innerText !== '') {
+                pEle.innerText = 'Enter a valid email address';
+              }
+            });
       });
 
     document


### PR DESCRIPTION
This PR follows #437 and #438. 
The update changes default error message to "Enter a valid email address" when creating a new account with email.