### PR TITLE
fix error when checking account

### DIFF
--- a/js/pages/homePage.js
+++ b/js/pages/homePage.js
@@ -1,4 +1,4 @@
-import { getMyData, renderSyndicate, urls, fragment, checkAccount, validEmailFormat, validPhoneNumberFormat } from "../shared.js";
+import { getMyData, renderSyndicate, urls, fragment, checkAccount, validEmailFormat, validPhoneNumberFormat, appState } from "../shared.js";
 import { signInConfig, signInConfigDev } from "./signIn.js";
 import { environmentWarningModal } from "../event.js";
 
@@ -452,8 +452,12 @@ export async function signInCheckRender ({ ui }) {
   }
 
 async function signInAnonymously() {
-  let user = null;
-  user = await firebase.auth().signInAnonymously();
-  
+  const { user } = await firebase.auth().signInAnonymously();
+
+  if (user) {
+    const idToken = await user.getIdToken();
+    appState.setState({ idToken, isAnonymous: true });
+  }
+
   return user;
 }


### PR DESCRIPTION
This PR follows #437, #438 and #439.
The update makes sure `idToken` is set before calling `checkAccount()`.