### PR TITLE
replace characters in email for query

### DIFF
--- a/js/pages/homePage.js
+++ b/js/pages/homePage.js
@@ -262,7 +262,17 @@ export async function signInCheckRender ({ ui }) {
 
       if (isEmail) {
         await signInAnonymously();
-        const response = await checkAccount({ accountType: 'email', accountValue: inputStr });
+        const emailForQuery = inputStr
+          .replaceAll('%', '%25')
+          .replaceAll('#', '%23')
+          .replaceAll('&', '%26')
+          .replaceAll(`'`, '%27')
+          .replaceAll('+', '%2B');
+
+        const response = await checkAccount({
+          accountType: 'email',
+          accountValue: emailForQuery,
+        });
 
         if (response?.data?.accountExists) {
           const account = { type: 'email', value: inputStr };


### PR DESCRIPTION
This PR update #437, to solve email search error for some accounts (eg: me+apitest@gmailcom).
Special characters (`%`, `#`, `&`, `'`, `+`) are replaced before adding to url.