### PR TITLE
add kpga kphi kpco and kpnw to the sample page

### DIFF
--- a/js/pages/samples.js
+++ b/js/pages/samples.js
@@ -5,17 +5,17 @@ export const renderSamplesPage = async () => {
 
     getMyData().then(res => {
         const site = locations.filter(location => location.concept == res.data['827220437'])[0];
-
+        
         let template; 
 
-        if(site) {
+        if(site && site !== kpga && site !==  kphi && site !==  kpco && site !==  kpnw) {
             const locationTemplate = renderLocations(site);
 
             template = `
             <br>
             
             <div class="row">
-                <div class="col-md-2">
+            <div class="col-md-2">
                 </div>
                 <div class="col-md-8">
                     <div class="row" style="width:100%">
@@ -140,6 +140,123 @@ export const renderSamplesPage = async () => {
                 <div class="col-md-2">
                 </div>
             </div>    
+            `;
+        }
+        else if (site && (site === kpga || site ===  kphi || site ===  kpco || site ===  kpnw)) {
+            const locationTemplate = renderLocations(site);
+            template = `
+            <br>
+            
+            <div class="row">
+            <div class="col-md-2">
+                </div>
+                <div class="col-md-8">
+                    <div class="row" style="width:100%">
+                        <div class="consentHeadersFont" style="color:#606060;width:100%">
+                            <div>
+                                Donating Your Samples at ${site.name}
+                            </div>
+                        </div>
+                        <div class="messagesBodyFont" style="width:100%">
+                            <div>
+                                ${site.donatingSamples}
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row" style="width:100%">
+                        <div class="consentHeadersFont" style="color:#606060;width:100%">
+                            <div>
+                                When Should I Donate My Samples?
+                            </div>
+                        </div>
+                        <div class="messagesBodyFont" style="width:100%">
+                            <div>
+                                ${site.whenToDonate}
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row" style="width:100%">
+                        <div class="consentHeadersFont" style="color:#606060;width:100%">
+                            <div>
+                                How Do I Donate My Blood and Urine Samples?
+                            </div>
+                        </div>
+                        <div class="messagesBodyFont" style="width:100%">
+                            <div>
+                                ${site.howToDonateBloodAndUrine}
+                            </div>
+                        </div>          
+                    </div>
+                    <div class="row" style="width:100%">
+                        <div class="consentHeadersFont" style="color:#606060;width:100%">
+                            <div>
+                            ${site.prepInstructionsHeader}
+                            </div>
+                        </div>
+                        <div class="messagesBodyFont" style="width:100%">
+                            <div>
+                                ${site.prepInstructionsText}
+                            </div>
+                        </div>          
+                    </div>          
+                    <div class="row" style="width:100%">
+                        <div class="consentHeadersFont" style="color:#606060;width:100%">
+                            <div>
+                                What Will Happen During My Visit?
+                            </div>
+                        </div>
+                        <div class="messagesBodyFont" style="width:100%">
+                            <div>
+                                ${site.whatHappensDuring}
+                            </div>
+                        </div>          
+                    </div>  
+                    <div class="row" style="width:100%">
+                        <div class="consentHeadersFont" style="color:#606060;width:100%">
+                            <div>
+                                What Will Happen After My Visit?
+                            </div>
+                        </div>
+                        <div class="messagesBodyFont" style="width:100%">
+                            <div>
+                                ${site.whatHappensAfter}
+                            </div>
+                        </div>          
+                    </div>
+                    <div class="row" style="width:100%">
+                        <div class="consentHeadersFont" style="color:#606060;width:100%">
+                            <div>
+                                How Do I Donate My Saliva Sample?
+                            </div>
+                        </div>
+                        <div class="messagesBodyFont" style="width:100%">
+                            <div>
+                                ${site.howToDonateSaliva}
+                            </div>
+                        </div>          
+                    </div>
+                    <div class="row" style="width:100%">
+                        <div class="consentHeadersFont" style="color:#606060;width:100%">
+                            <div>
+                                Questions? Contact the Connect Support Center
+                            </div>
+                        </div>
+                        <div class="messagesBodyFont" style="width:100%">
+                            <div>
+                                <a href="https://myconnect.cancer.gov/support">MyConnect.cancer.gov/support</a>
+                                <br>
+                                <br>
+                                <a href="mailto: ConnectSupport@norc.org">ConnectSupport@norc.org</a>
+                                <br>
+                                <br>
+                                ${site.support}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-2">
+                </div>
+            </div>     
             `;
         }
         else {
@@ -313,13 +430,73 @@ const nci = {
     ]
 };
 
+const kpga = {
+    concept: '7677759349',
+    name: 'KP Georgia',
+    donatingSamples: 'As part of Connect, we ask you to donate blood, urine, and saliva samples and complete two short surveys.',
+    whenToDonate: 'We will send you an email when it is time to donate your samples. After you receive the email, it is important to donate your samples as soon as you can.',
+    howToDonateBloodAndUrine: 'Please visit the lab at any Kaiser Permanente location that is convenient for you.<br></br><span style="font-weight:900;">You do not need an appointment</span> and there is no co-pay involved. You may eat and drink before your visit.<br></br>When you arrive at the Kaiser Permanente lab, please use the lab kiosk to check in according to the steps below:<br></br><ol><li> Touch the screen to get started.</li><li> Enter your Medical Record Number (MRN).</li><li> Enter your Date of Birth.</li><li> Choose “Walk-in.”</li><li> Select “Other Lab Services.”</li><li> Answer COVID-19 symptoms questions if displayed.</li><li> Select “No” to answer questions regarding additional coverage, payment, or text messaging.</li><li> You will see a message on the kiosk screen that reads, “You are checked-in" when you have finished the check-in process.</li><li> Have a seat and lab staff will call you back when they are ready.</li><li> When called back, please communicate with the lab staff you are there for a “Research draw for Connect” and the KP lab staff will take it from there.</li></ol>If possible, please go to the lab <span style="font-weight:900;">Monday - Thursday before 2:00 p.m.</span><br></br>For locations, hours and directions, please visit <a style="text-decoration:underline" href="https://healthy.kaiserpermanente.org/georgia/doctors-locations?kp_shortcut_referrer=kp.org/locations#/search-form">kp.org/locations</a> or call 1-888-413-0601.<br></br><span style="font-weight:900;">Note:</span> If you have recently had a blood transfusion or donated blood, please wait at least <span style="font-weight:900;">eight weeks</span> from your donation or transfusion before donating your samples for Connect. If you have recently donated plasma, please wait at least <span style="font-weight:900;">two days</span> from your plasma donation before donating samples for Connect. If you have an upcoming colonoscopy, please be sure that you <span style="font-weight:900;">do not</span> donate samples for Connect on the <span style="font-weight:900;">same day</span> as your colonoscopy.',
+    prepInstructionsHeader: 'How Should I Prepare On the Day of My Visit?',
+    prepInstructionsText: '<span style="font-style:italic;">All patients are required to wear a mask when visiting any Kaiser Permanente facility. If you enter the building without a mask, one will be provided to you. If you are unable to wear a mask for the duration of the visit, we ask that you do not plan to visit at this time.</span><br></br>A visitor may accompany you in the lab waiting area but they will not be permitted back to the lab area with you. Hand sanitizer will be available for your use. Please follow any physical distancing guidelines provided in the facility.<br></br><span style="font-weight:900;">Things to bring and remember:</span><br></br><ul><li>Please bring your Kaiser Permanente ID card and a picture ID.</li><ul>',
+    whatHappensDuring: 'Donating your research blood and urine samples is just like providing samples requested by your health care provider. When you arrive at the facility, you may go directly to the lab to check in according to the steps above.<br></br>When it is your turn, the lab will call you back, confirm your ID, and collect your samples.',
+    whatHappensAfter: 'Within a day of your blood and urine donation, we will send you an email asking you to complete a short survey on the MyConnect app. The survey will ask about recent actions, such as:<br></br><ul style="list-style-type:circle;"><li>The last time you ate or drank before your visit, and the times you went to sleep the night before your visit and woke up on the day of your visit.</li><li> If you are menstruating, the start date of your most recent menstrual period in the last 12 months.</li><li> Information and dates regarding COVID-19 testing, symptoms, recovery information (including any hospital stay and treatment), and vaccination status.</li></ul><span style="font-style:italic; font-weight:900;">When you receive our email, it is important that you complete the survey as soon as possible.</span>',
+    howToDonateSaliva: 'You can do this in the comfort of your own home. When it is time to donate your saliva sample, we will mail you a mouthwash home collection kit. This kit will include instructions and all of the items needed to collect your sample, including a return shipping box with a pre-paid shipping label to return your sample to us.<br></br>When you collect your saliva sample, we will ask you to complete a short survey on the MyConnect app.<p style="font-weight:900; font-style:italic;"> It is important to complete this survey on the same day that you collect your saliva sample.</p>',
+    support: 'Call 1-877-505-0253 (9:00 a.m-11:00 p.m. ET on weekdays and 10:00 a.m.-7:00 p.m. ET on weekends)'
+};
+
+const kphi = {
+    concept: '5313139567',
+    name: 'KP Hawaii',
+    donatingSamples: 'As part of Connect, we ask you to donate blood, urine, and saliva samples and complete two short surveys.',
+    whenToDonate: 'We will send you an email when it is time to donate your samples. After you receive the email, it is important to donate your samples as soon as you can.',
+    howToDonateBloodAndUrine: 'Please visit the lab at any Kaiser Permanente location convenient for you.<br></br><span style="font-weight:900;">You do not need an appointment</span> and there is no co-pay involved. You may eat and drink before your visit.<br></br>If possible, please go to the lab <span style="font-weight:900;">Monday - Thursday before 2:00 p.m.</span><br></br>For locations, hours, and directions, please go to <a style="text-decoration:underline" href="https://healthy.kaiserpermanente.org/hawaii/doctors-locations?kp_shortcut_referrer=kp.org/locations#/search-form">kp.org/locations</a> or call <span style="font-weight:900;">toll-free 833-417-0846.</span><br></br><span style="font-weight:900;">Note:</span> If you have recently had a blood transfusion or donated blood, please wait at least <span style="font-weight:900;">eight weeks</span> from your donation or transfusion before donating your samples for Connect. If you have recently donated plasma, please wait at least <span style="font-weight:900;">two days</span> from your plasma donation before donating samples for Connect. If you have an upcoming colonoscopy, please be sure that you <span style="font-weight:900;">do not</span> donate samples for Connect on the <span style="font-weight:900;">same day</span> as your colonoscopy.',
+    prepInstructionsHeader: 'What Should I Bring to the Visit?',
+    prepInstructionsText: '<ul><li>Please bring your Kaiser Permanente member ID card and a picture ID.</li><li>All patients and visitors are required to wear a mask and practice physical distancing within the KP facility.</li></ul><span style="font-style:italic;">Note: Hand sanitizer will be available for your use.</span>',
+    whatHappensDuring: 'Donating your research blood and urine samples is just like providing samples requested by your health care provider. When you arrive at the clinic, you may go directly to the lab. When it is your turn, the lab will call you back, check your ID, and collect your samples.',
+    whatHappensAfter: 'Within a day of your blood and urine donation, we will send you an email asking you to complete a short survey on the MyConnect app. The survey will ask about recent actions, such as:<ul style="list-style-type:circle;"><li>The last time you ate or drank before your visit, and the times you went to sleep the night before your visit and woke up on the day of your visit.</li><li>If you are menstruating, the start date of your most recent menstrual period in the last 12 months.</li><li>Information and dates regarding COVID-19 testing, symptoms, recovery information (including any hospital stay and treatment), and vaccination status.</li></ul><span style="font-style:italic; font-weight:900;">When you receive our email, it is important that you complete the survey as soon as possible.</span>',
+    howToDonateSaliva: 'You can do this in the comfort of your own home. When it is time to donate your saliva sample, we will mail you a mouthwash home collection kit. This kit will include instructions and all of the items needed to collect your sample, including a return shipping box with a pre-paid shipping label to return your sample to us.<br></br>When you collect your saliva sample, we will ask you to complete a short survey on the MyConnect app.<p style="font-style:italic; font-weight:900;">It is important to complete this survey on the same day that you collect your saliva sample.</p>',
+    support: 'Call 1-877-505-0253 (3:00 a.m-5:00 p.m. HT on weekdays and 4:00 a.m.-1:00 p.m. HT on weekends)'
+};
+
+const kpco = {
+    concept: '7632731126',
+    name: 'KP Colorado',
+    donatingSamples: 'As part of Connect, we ask you to donate blood, urine, and saliva samples and complete two short surveys.',
+    whenToDonate: 'We will send you an email when it is time to donate your samples. After you receive the email, it is important to donate your samples as soon as you can.',
+    howToDonateBloodAndUrine: 'Please visit the lab at any Kaiser Permanente location that is convenient for you.<br></br><span style="font-weight:900;">You do not need an appointment</span> and there is no co-pay involved. You may eat and drink before your visit.<br></br>If possible, please go to the lab <span style="font-weight:900;">Monday - Thursday before 2:00 p.m.</span><br></br>For locations, hours and directions, please visit <a style="text-decoration:underline" href="https://healthy.kaiserpermanente.org/colorado/doctors-locations?kp_shortcut_referrer=kp.org/locations#/search-form">kp.org/locations</a> or call 303-338-3800.<br></br><span style="font-weight:900;">Note:</span> If you have recently had a blood transfusion or donated blood, please wait at least <span style="font-weight:900;">eight weeks</span> from your donation or transfusion before donating your samples for Connect. If you have recently donated plasma, please wait at least <span style="font-weight:900;">two days</span> from your plasma donation before donating samples for Connect. If you have an upcoming colonoscopy, please be sure that you <span style="font-weight:900;">do not</span> donate samples for Connect on the <span style="font-weight:900;">same day</span> as your colonoscopy.',
+    prepInstructionsHeader: 'How Should I Prepare on the Day of My Visit?',
+    prepInstructionsText: '<span style="font-style:italic;">All patients and visitors are required to wear a mask when you visit any Kaiser Permanente building. If you enter the building without a mask, one will be provided to you. Hand sanitizer will be available for your use. Please follow any physical distancing guidelines provided in the clinic.</span><br></br><span style="font-weight:900;">Things to bring and remember:<br></br></span><ul><li>Please bring your Kaiser Permanente member ID card and a picture ID.</li></ul>',
+    whatHappensDuring: 'Donating your research blood and urine samples is just like providing samples requested by your health care provider. When you arrive at the clinic, you may go directly to the lab. When it is your turn, the lab will call you back, check your ID, and collect your samples.',
+    whatHappensAfter: 'Within a day of your blood and urine donation, we will send you an email asking you to complete a short survey on the MyConnect app. The survey will ask about recent actions, such as:<br></br><ul style="list-style-type:circle;"><li>The last time you ate or drank before your visit, and the times you went to sleep the night before your visit and woke up on the day of your visit.</li><li>If you are menstruating, the start date of your most recent menstrual period in the last 12 months.</li><li>Information and dates regarding COVID-19 testing, symptoms, recovery information (including any hospital stay and treatment), and vaccination status.</li></ul><span style="font-style:italic; font-weight:900;">When you receive our email, it is important that you complete the survey as soon as possible.</span>',
+    howToDonateSaliva: 'You can do this in the comfort of your own home. When it is time to donate your saliva sample, we will mail you a mouthwash home collection kit. This kit will include instructions and all of the items you need to collect your sample, including a return shipping box with a pre-paid shipping label to return your sample to us.<br></br>When you collect your saliva sample, we will ask you to complete a short survey on the MyConnect app.<p style="font-style:italic; font-weight:900;">It is important to complete this survey on the same day that you collect your saliva sample.</p>',
+    support: 'Call 1-877-505-0253 (7:00 a.m-9:00 p.m. CT on weekdays and 8:00 a.m.-5:00 p.m. CT on weekends)'
+};
+
+const kpnw = {
+    concept: '7156328758',
+    name: 'KP Northwest',
+    donatingSamples: 'As part of Connect, we ask you to donate blood, urine, and saliva samples and complete two short surveys.',
+    whenToDonate: 'We will send you an email when it is time to donate your samples. After you receive the email, it is important to donate your samples as soon as you can.',
+    howToDonateBloodAndUrine: 'Please visit the lab at any Kaiser Permanente location that is convenient for you.<br></br><span style="font-weight:900;">You do not need an appointment</span> and there is no co-pay involved. You may eat and drink before your visit.<br></br>If possible, please go to the lab <span style="font-weight:900;">Monday - Thursday before 2:00 p.m.</span><br></br>For locations, hours and directions, please visit <a style="text-decoration:underline" href="https://healthy.kaiserpermanente.org/oregon-washington/community-providers/laboratory">kp.org/locations.</a><br></br><span style="font-weight:900;">Note:</span> If you have recently had a blood transfusion or donated blood, please wait at least <span style="font-weight:900;">eight weeks</span> from your donation or transfusion before donating your samples for Connect. If you have recently donated plasma, please wait at least <span style="font-weight:900;">two days</span> from your plasma donation before donating samples for Connect. If you have an upcoming colonoscopy, please be sure that you <span style="font-weight:900;">do not</span> donate samples for Connect on the <span style="font-weight:900;">same day</span> as your colonoscopy.',
+    prepInstructionsHeader: 'What Should I Bring to the Visit?',
+    prepInstructionsText: '<ul><li>Please bring your Kaiser Permanente member ID card and a picture ID.</li><li>All patients and visitors are required to wear a mask and practice physical distancing within the KP facility.</li></ul><span style="font-style:italic;">Note: Hand sanitizer will be available for your use.</span>',
+    whatHappensDuring: 'Donating your research blood and urine samples is just like providing a clinical sample requested by your health care provider. When you arrive at the clinic, you may go directly to the lab, get a ticket with a number, and follow the instructions. When it is your turn, the lab staff will call your number and explain how your sample donation will work.',
+    whatHappensAfter: 'Within a day of your blood and urine donation, we will send you an email asking you to complete a short survey on the MyConnect app. The survey will ask about recent actions, such as:<br></br><ul  style="list-style-type:circle;"><li>The last time you ate or drank before your visit, and the times you went to sleep the night before your visit and woke up on the day of your visit.</li><li>If you are menstruating, the start date of your most recent menstrual period in the last 12 months.</li><li>Information and dates regarding COVID-19 testing, symptoms, recovery information (including any hospital stay and treatment), and vaccination status.</li></ul><span style="font-weight:900; font-style:italic;">When you receive our email, it is important that you complete the survey as soon as possible.</span>',
+    howToDonateSaliva: 'You can do this in the comfort of your own home. When it is time to donate your saliva sample, we will mail you a mouthwash home collection kit. This kit will include instructions and all of the items needed to collect your sample, including a return shipping box with a pre-paid shipping label to return your sample to us.<br></br>When you collect your saliva sample, we will ask you to complete a short survey on the MyConnect app.<p style="font-weight:900;">It is important to complete this survey on the same day that you collect your saliva sample.</p>',
+    support: 'Call 1-877-505-0253 (6:00 a.m-8:00 p.m. PT on weekdays and 7:00 a.m.-4:00 p.m. PT on weekends)'
+};
+
 const locations = [
     health_partners,
     sanford,
     marshfield,
     henry_ford,
     u_chicago,
-    nci
+    nci,
+    kpga,
+    kphi,
+    kpco,
+    kpnw
 ];
 
 
@@ -327,53 +504,54 @@ const renderLocations = (site) => {
     let template = '';
 
     console.log(site.locations);
-
-    site.locations.forEach(location => {
-        template += `
-            <div class="row" style="width:100%">
-                <div class="messagesHeaderFont">
-                    ${location[0]}
-                </div>
-            </div>
-
-            <div class="row" style="width:100%">
-                <div style="width:100%">
+    if(site.locations){
+        site.locations.forEach(location => {
+            template += `
+                <div class="row" style="width:100%">
                     <div class="messagesHeaderFont">
-                        Address and Directions
-                    </div>
-                    <div class="messagesBodyFont">
-                        ${location[1]}
+                        ${location[0]}
                     </div>
                 </div>
-            </div>
-
-            <div class="row" style="width:100%">
-                <div style="width:100%">
-                    <div class="messagesHeaderFont">
-                        Hours
-                    </div>
-                    <div class="messagesBodyFont">
-                        ${location[2]}
-                    </div>
-                </div>
-            </div>
-
-            <div class="row" style="width:100%">
-                <div style="width:100%">
-                    <div class="messagesHeaderFont">
-                        Parking Instructions
-                    </div>
-                    <div class="messagesBodyFont">
-                        ${location[3]}
+    
+                <div class="row" style="width:100%">
+                    <div style="width:100%">
+                        <div class="messagesHeaderFont">
+                            Address and Directions
+                        </div>
+                        <div class="messagesBodyFont">
+                            ${location[1]}
+                        </div>
                     </div>
                 </div>
-            </div>
-
-            <div class="row" style="width:100%"></div>
-            <br>
-            <br>
-        `;
-    });
+    
+                <div class="row" style="width:100%">
+                    <div style="width:100%">
+                        <div class="messagesHeaderFont">
+                            Hours
+                        </div>
+                        <div class="messagesBodyFont">
+                            ${location[2]}
+                        </div>
+                    </div>
+                </div>
+    
+                <div class="row" style="width:100%">
+                    <div style="width:100%">
+                        <div class="messagesHeaderFont">
+                            Parking Instructions
+                        </div>
+                        <div class="messagesBodyFont">
+                            ${location[3]}
+                        </div>
+                    </div>
+                </div>
+    
+                <div class="row" style="width:100%"></div>
+                <br>
+                <br>
+            `;
+        });
+    }
 
 
     return template;


### PR DESCRIPTION
Added in a new template because these four are in a slightly different order than other locations.

The Preparation instruction area kpnw and kphi has a header of "What should I Bring to the Visit?" while kpco and kpga the header is "How Should I prepare on the Day of My Visit?" -- this is the reason why there is a prepInstructionsHeader key as well as a prepInstructionsText key.

the new json files use the following keys:
{
    concept: text;
    name: text;
    donatingSamples: text;
    whenToDonate: text;
    howToDonateBloodAndUrine: text;
    prepInstructionsHeader: text;
    prepInstructionsText: text;
    whatHappensDuring: text;
    whatHappensAfter: text;
    howToDonateSaliva: text;
    support: text;
}