### PR TITLE
Fix incorrect sign-in time

### DIFF
--- a/js/event.js
+++ b/js/event.js
@@ -1044,13 +1044,14 @@ export const addEventRequestPINForm = (accountCreatedAt) => {
         showAnimation();
         const pin = document.getElementById('participantPIN').value;
         const mainContent = document.getElementById('root');
+        let formData = {};
+        formData["335767902"] = (new Date(parseInt(accountCreatedAt))).toISOString(); // Store account creation time
+
         if(pin && pin !== ""){
             const response = await validatePin(pin);
             if(response.code !== 200){
                 await generateNewToken();
-                let formData = {};
                 formData["379080287"] = pin;
-                formData["335767902"] = (new Date(parseInt(accountCreatedAt))).toISOString(); // Store account creation time
                 await storeResponse(formData);
                 hideAnimation();
                 mainContent.innerHTML = healthCareProvider();
@@ -1058,9 +1059,7 @@ export const addEventRequestPINForm = (accountCreatedAt) => {
                 addEventHealthProviderModalSubmit();
             }
             if(response.code === 200){
-                let formData = {};
                 formData["379080287"] = pin;
-                formData["335767902"] = (new Date(parseInt(accountCreatedAt))).toISOString(); // Store account creation time
                 await storeResponse(formData);
                 hideAnimation();
                 mainContent.innerHTML =  heardAboutStudy();
@@ -1069,8 +1068,6 @@ export const addEventRequestPINForm = (accountCreatedAt) => {
             
         }else{
             await generateNewToken();
-            let formData = {};
-            formData["335767902"] = (new Date(parseInt(accountCreatedAt))).toISOString(); // Store account creation time
             formData["828729648"] = 353358909;
             await storeResponse(formData);
             hideAnimation();

--- a/js/pages/consent.js
+++ b/js/pages/consent.js
@@ -1100,7 +1100,6 @@ const consentSubmit = async e => {
         formData['430184574'] = CSWDate.split('/')[2] + CSWDate.split('/')[1] + CSWDate.split('/')[0]
     }
     formData['507120821'] = 596523216;
-    formData['335767902'] = new Date().toISOString();
     
     const response = await storeResponse(formData);
     if(response.code === 200) consentFinishedPage ();

--- a/js/shared.js
+++ b/js/shared.js
@@ -8,7 +8,7 @@ export const urls = {
 }
 
 function createStore(initialState = {}) {
-  let state = JSON.parse(JSON.stringify(initialState));
+  let state = initialState;
 
   const setState = (update) => {
     const currSlice = typeof update === 'function' ? update(state) : update;


### PR DESCRIPTION
This PR fiexes issue [#610](https://github.com/episphere/connect/issues/610). Below are details:

- `formData['335767902'] = new Date().toISOString();` is removed from `consentSubmit()`. This line is the source of the problem. The value of CID 335767902 is set when a user responds to the first page (about the PIN) after logging in, so there's no need to set it again when the consent is submitted.

- Clean up some code.