### PR TITLE
New tab in devices with touchscreen

### DIFF
--- a/js/pages/consent.js
+++ b/js/pages/consent.js
@@ -786,13 +786,13 @@ const consentConsentPage = async () => {
         consentIndigenousPage();
     })
 
-    let newTab = null;
+    let urlToNewTabMap = {};
 
     function openNewTab(url) {
-      if (newTab === null || newTab.closed) {
-        newTab = window.open(url);
+      if (!urlToNewTabMap[url] || urlToNewTabMap[url].closed) {
+        urlToNewTabMap[url] = window.open(url);
       } else {
-        newTab.focus();
+        urlToNewTabMap[url].focus();
       }
     } 
 

--- a/js/shared.js
+++ b/js/shared.js
@@ -1156,7 +1156,31 @@ export const validPhoneNumberFormat =
   }
 
 /**
- * Detect if current device is mobile
+ * Check if current device is a mobile device (smartphone, tablet, or others with touch screen)
  * @returns {boolean}
  */
-  export const isMobile = /Mobi/.test(navigator.userAgent);
+function checkDeviceMobile() {
+  let isMobile = false;
+
+  if ('maxTouchPoints' in navigator) {
+    isMobile = navigator.maxTouchPoints > 0;
+  } else if ('msMaxTouchPoints' in navigator) {
+    isMobile = navigator.msMaxTouchPoints > 0;
+  } else {
+    const mediaQuery = matchMedia?.('(pointer:coarse)');
+    if (mediaQuery?.media === '(pointer:coarse)') {
+      isMobile = !!mediaQuery.matches;
+    } else if ('orientation' in window) {
+      isMobile = true;
+    } else {
+      isMobile = /Mobi|Android|Tablet|iPad|iPhone|iPod|webOS/i.test(
+        navigator.userAgent
+      );
+    }
+  }
+
+  return isMobile;
+}
+
+export const isMobile = checkDeviceMobile();
+


### PR DESCRIPTION
This PR updates [PR #485](https://github.com/episphere/connectApp/pull/485), to solve issue [#98](https://github.com/episphere/connectApp/issues/98). Below are details:
- Updated mobile device check, based on feedbacks from PR #485. Beside phones, the new tab feature will also apply to tablets and other devices with touchscreens.
- Handle multiple new tabs.

Note: This update needs to be tested on Windows desktop or laptop with touchscreens, to make sure the download links work as expected.

References:
- [Mobile device detection](https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#mobile_device_detection)
- [Media Features](https://www.w3.org/TR/mediaqueries-4/#mf-interaction)
- [Window.navigator](https://developer.mozilla.org/en-US/docs/Web/API/Window/navigator)
- [Online discussion](https://stackoverflow.com/questions/50195475/detect-if-device-is-tablet)