### PR TITLE
New tab for signed consent forms in mobile

### DIFF
--- a/js/pages/agreements.js
+++ b/js/pages/agreements.js
@@ -318,7 +318,6 @@ export const renderDownloadConsentCopy = async (data) => {
     }
 
     renderDownload(participantSignature, currentTime, pdfLocation, {x:coords.nameX,y:coords.nameY},{x1:coords.signatureX,y1:coords.signatureY},{x:coords.dateX,y:coords.dateY},24,24,20);
-
 }
 
 export const renderDownloadHIPAA = async (data) => {
@@ -341,7 +340,6 @@ export const renderDownloadHIPAA = async (data) => {
     }
 
     renderDownload(participantSignature, currentTime, pdfLocation, {x:coords.nameX,y:coords.nameY},{x1:coords.signatureX,y1:coords.signatureY},{x:coords.dateX,y:coords.dateY},24,24,20);
-    
 }
 
 
@@ -460,14 +458,11 @@ const renderDownload = async (participant, timeStamp, fileLocation, nameCoordina
     let fileLocationDownload = fileLocation.slice(2)
     const participantPrintName = participant
     const participantSignature = participant
-    let seekLastPage;
     const pdfLocation = fileLocation;
     const existingPdfBytes = await fetch(pdfLocation).then(res => res.arrayBuffer());
     const pdfDoc = await PDFDocument.load(existingPdfBytes);
     const helveticaFont = await pdfDoc.embedFont(StandardFonts.TimesRomanItalic);
-    const pages = pdfDoc.getPages();
-    for (let i = 0; i <= pages.length; i++) {seekLastPage = i}
-    const editPage = pages[seekLastPage-1];
+    const editPage = pdfDoc.getPages().at(-1);
 
     editPage.drawText(`
     ${participantPrintName}`, {
@@ -574,6 +569,7 @@ async function generateSignedPdf(data, file) {
     sourcePdfLocation = './forms/consent/' + data[454205108] + '.pdf';
     timeStamp = new Date(data[454445267]).toLocaleDateString();
     coords = signaturePosConsentJSON[participantSite];
+
     if (!coords) {
       coords = {
         nameX: 110,
@@ -584,10 +580,12 @@ async function generateSignedPdf(data, file) {
         dateY: 370,
       };
     }
+
   } else if (file === 'signed-HIPAA') {
     sourcePdfLocation = './forms/HIPAA/' + data[412000022] + '.pdf';
     timeStamp = new Date(data[262613359]).toLocaleDateString();
     coords = signaturePosJSON[participantSite];
+
     if (!coords) {
       coords = {
         nameX: 200,
@@ -598,6 +596,7 @@ async function generateSignedPdf(data, file) {
         dateY: 325,
       };
     }
+
   }
 
   const sourcePdfBytes = await fetch(sourcePdfLocation).then((res) =>
@@ -605,8 +604,7 @@ async function generateSignedPdf(data, file) {
   );
   const pdfDoc = await PDFDocument.load(sourcePdfBytes);
   const helveticaFont = await pdfDoc.embedFont(StandardFonts.TimesRomanItalic);
-  const pageArray = pdfDoc.getPages();
-  const pageToEdit = pageArray[pageArray.length - 1];
+  const pageToEdit = pdfDoc.getPages().at(-1);
 
   pageToEdit.drawText(participantFullName, {
     x: coords.nameX,

--- a/js/pages/agreements.js
+++ b/js/pages/agreements.js
@@ -554,10 +554,10 @@ const consentSignTemplate = () => {
 /**
  * Generates a signed PDF file, and returns the URL of the file
  * @param {object} data
- * @param {'consent'| 'HIPAA'} fileType
+ * @param {'signed-consent'| 'signed-HIPAA'} file
  * @returns Promise<string>
  */
-async function generateSignedPdf(data, fileType) {
+async function generateSignedPdf(data, file) {
   let sourcePdfLocation;
   let coords;
   let timeStamp;
@@ -570,7 +570,7 @@ async function generateSignedPdf(data, fileType) {
     signatureSize: 20,
   };
 
-  if (fileType === 'consent') {
+  if (file === 'signed-consent') {
     sourcePdfLocation = './forms/consent/' + data[454205108] + '.pdf';
     timeStamp = new Date(data[454445267]).toLocaleDateString();
     coords = signaturePosConsentJSON[participantSite];
@@ -584,7 +584,7 @@ async function generateSignedPdf(data, fileType) {
         dateY: 370,
       };
     }
-  } else if (fileType === 'HIPAA') {
+  } else if (file === 'signed-HIPAA') {
     sourcePdfLocation = './forms/HIPAA/' + data[412000022] + '.pdf';
     timeStamp = new Date(data[262613359]).toLocaleDateString();
     coords = signaturePosJSON[participantSite];
@@ -638,7 +638,7 @@ async function generateSignedPdf(data, fileType) {
  * @param {MouseEvent} evt mouse click event
  * @returns 
  */
-export async function handleSignedPdfDownload(data, evt) {
+export async function downloadSignedPdf(data, evt) {
   if (!evt.target.href) {
     evt.preventDefault();
     evt.target.href = await generateSignedPdf(data, evt.target.dataset.file);

--- a/js/pages/agreements.js
+++ b/js/pages/agreements.js
@@ -1,5 +1,6 @@
-import { getMyData, hideAnimation, showAnimation, siteAcronyms, dateTime, storeResponse,isMobile, openNewTab} from "../shared.js";
+import { getMyData, hideAnimation, showAnimation, siteAcronyms, dateTime, storeResponse, isMobile, openNewTab } from "../shared.js";
 import { initializeCanvas } from './consent.js'
+
 const { PDFDocument, StandardFonts } = PDFLib;
 
 let signaturePosJSON = {
@@ -14,6 +15,7 @@ let signaturePosJSON = {
     "KPNW": {nameX:110,nameY:410,signatureX:110,signatureY:450,dateX:110,dateY:370}
 
 }
+
 let signaturePosConsentJSON = {
     "HP":{nameX:90,nameY:415,signatureX:110,signatureY:340,dateX:90,dateY:380},
     "Sanford":{nameX:120,nameY:410,signatureX:120,signatureY:450,dateX:120,dateY:370},
@@ -26,6 +28,7 @@ let signaturePosConsentJSON = {
     "KPNW": {nameX:110,nameY:390,signatureX:110,signatureY:310,dateX:110,dateY:345}
 
 }
+
 export const renderAgreements = async () => {
     document.title = 'My Connect - Forms';
     showAnimation();
@@ -294,9 +297,6 @@ const addEventAgreementOptions = (myData) => {
         })
     }
 }
-
-
-
 
 export const renderDownloadConsentCopy = async (data) => {
     const pdfLocation = './forms/consent/' + data[454205108] + '.pdf';
@@ -568,35 +568,25 @@ async function generateSignedPdf(data, file) {
   if (file === 'signed-consent') {
     sourcePdfLocation = './forms/consent/' + data[454205108] + '.pdf';
     timeStamp = new Date(data[454445267]).toLocaleDateString();
-    coords = signaturePosConsentJSON[participantSite];
-
-    if (!coords) {
-      coords = {
-        nameX: 110,
-        nameY: 400,
-        signatureX: 110,
-        signatureY: 330,
-        dateX: 110,
-        dateY: 370,
-      };
-    }
-
+    coords = signaturePosConsentJSON[participantSite] ?? {
+      nameX: 110,
+      nameY: 400,
+      signatureX: 110,
+      signatureY: 330,
+      dateX: 110,
+      dateY: 370,
+    };
   } else if (file === 'signed-HIPAA') {
     sourcePdfLocation = './forms/HIPAA/' + data[412000022] + '.pdf';
     timeStamp = new Date(data[262613359]).toLocaleDateString();
-    coords = signaturePosJSON[participantSite];
-
-    if (!coords) {
-      coords = {
-        nameX: 200,
-        nameY: 275,
-        signatureX: 200,
-        signatureY: 225,
-        dateX: 200,
-        dateY: 325,
-      };
-    }
-
+    coords = signaturePosJSON[participantSite] ?? {
+      nameX: 200,
+      nameY: 275,
+      signatureX: 200,
+      signatureY: 225,
+      dateX: 200,
+      dateY: 325,
+    };
   }
 
   const sourcePdfBytes = await fetch(sourcePdfLocation).then((res) =>

--- a/js/pages/agreements.js
+++ b/js/pages/agreements.js
@@ -1,4 +1,4 @@
-import { getMyData, hideAnimation, showAnimation, siteAcronyms, dateTime, storeResponse, renderPdfBytesInNewTab, isMobile } from "../shared.js";
+import { getMyData, hideAnimation, showAnimation, siteAcronyms, dateTime, storeResponse,isMobile, openNewTab} from "../shared.js";
 import { initializeCanvas } from './consent.js'
 const { PDFDocument, StandardFonts } = PDFLib;
 
@@ -299,63 +299,47 @@ const addEventAgreementOptions = (myData) => {
 
 
 export const renderDownloadConsentCopy = async (data) => {
-
-    let pdfLocation = './forms/consent/' + data[454205108] + '.pdf'
-    //let pdfLocation = './forms/consent/' + 'UChicago_Consent_V1.0' + '.pdf'
-    let pdfName = data[454205108] + '.pdf';
-    const participantSignature = data[471168198] + ' ' + data[736251808]
-    let seekLastPage;
-    //const pdfLocation = './consent_draft.pdf';
-    const existingPdfBytes = await fetch(pdfLocation).then(res => res.arrayBuffer());
-    const pdfConsentDoc = await PDFDocument.load(existingPdfBytes);
-    const helveticaFont = await pdfConsentDoc.embedFont(StandardFonts.TimesRomanItalic);
-    const pages = pdfConsentDoc.getPages();
-    for (let i = 0; i <= pages.length; i++) {seekLastPage = i}
-    const editPage = pages[seekLastPage-1];
+    const pdfLocation = './forms/consent/' + data[454205108] + '.pdf';
+    const participantSignature = data[471168198] + ' ' + data[736251808];
     const currentTime = new Date(data[454445267]).toLocaleDateString();
-    let siteDict = siteAcronyms();
-    let participantSite = siteDict[data['827220437']];
-    //let participantSite = "UChicago"
-    let coords = signaturePosConsentJSON[participantSite]
-    //renderDownload(participantSignature, currentTime, pdfLocation, {x:110,y:400},{x1:110,y1:330});
-    if(!coords){
-        coords = {nameX:110,nameY:400,signatureX:110,signatureY:330,dateX:110,dateY:370}
+    const siteDict = siteAcronyms();
+    const participantSite = siteDict[data['827220437']]; // eg. 'UChicago'
+    let coords = signaturePosConsentJSON[participantSite];
+
+    if (!coords) {
+      coords = {
+        nameX: 110,
+        nameY: 400,
+        signatureX: 110,
+        signatureY: 330,
+        dateX: 110,
+        dateY: 370,
+      };
     }
+
     renderDownload(participantSignature, currentTime, pdfLocation, {x:coords.nameX,y:coords.nameY},{x1:coords.signatureX,y1:coords.signatureY},{x:coords.dateX,y:coords.dateY},24,24,20);
 
 }
 
 export const renderDownloadHIPAA = async (data) => {
-    //let pdfLocation = './forms/HIPAA/UChicago_HIPAA_V1.0.pdf'
-    let pdfLocation = './forms/HIPAA/' + data[412000022] + '.pdf'
-    let siteDict = siteAcronyms();
-    let participantSite = siteDict[data['827220437']];
-    //let participantSite = "UChicago"
-
+    const pdfLocation = './forms/HIPAA/' + data[412000022] + '.pdf';
+    const participantSignature = data[471168198] + ' ' + data[736251808];
+    const currentTime = new Date(data[262613359]).toLocaleDateString();
+    const siteDict = siteAcronyms();
+    const participantSite = siteDict[data['827220437']];
     let coords = signaturePosJSON[participantSite];
     
-    if(!coords){
-        coords = {
-            nameX:200,
-            nameY:275,
-            signatureX:200,
-            signatureY:225,
-            dateX:200,
-            dateY:325
-        }
+    if (!coords) {
+      coords = {
+        nameX: 200,
+        nameY: 275,
+        signatureX: 200,
+        signatureY: 225,
+        dateX: 200,
+        dateY: 325,
+      };
     }
 
-    let pdfName = data[412000022] + '.pdf';
-    const participantSignature = data[471168198] + ' ' + data[736251808]
-    let seekLastPage;
-    //const pdfLocation = './consent_draft.pdf';
-    const existingPdfBytes = await fetch(pdfLocation).then(res => res.arrayBuffer());
-    const pdfConsentDoc = await PDFDocument.load(existingPdfBytes);
-    const helveticaFont = await pdfConsentDoc.embedFont(StandardFonts.TimesRomanItalic);
-    const pages = pdfConsentDoc.getPages();
-    for (let i = 0; i <= pages.length; i++) {seekLastPage = i}
-    const editPage = pages[seekLastPage-1];
-    const currentTime = new Date(data[262613359]).toLocaleDateString();
     renderDownload(participantSignature, currentTime, pdfLocation, {x:coords.nameX,y:coords.nameY},{x1:coords.signatureX,y1:coords.signatureY},{x:coords.dateX,y:coords.dateY},24,24,20);
     
 }
@@ -363,30 +347,18 @@ export const renderDownloadHIPAA = async (data) => {
 
 const renderDownloadRevoke = async (data) => {
     const participantSignature = data[471168198] + ' ' + data[736251808]
-    let seekLastPage;
     const pdfLocation = './forms/HIPAA_Revocation_V1.0.pdf';
-    const existingPdfBytes = await fetch(pdfLocation).then(res => res.arrayBuffer());
-    const pdfConsentDoc = await PDFDocument.load(existingPdfBytes);
-    const helveticaFont = await pdfConsentDoc.embedFont(StandardFonts.TimesRomanItalic);
-    const pages = pdfConsentDoc.getPages();
-    for (let i = 0; i <= pages.length; i++) {seekLastPage = i}
-    const editPage = pages[seekLastPage-1];
     const currentTime = new Date(data[613641698]).toLocaleDateString();
+
     renderDownload(participantSignature, currentTime, pdfLocation, {x:150,y:420},{x1:150,y1:400},{x:155,y:380},20,15,20);
 }
 
 
 const renderDownloadDestroy = async (data) => {
     const participantSignature = data[471168198] + ' ' + data[736251808]
-    let seekLastPage;
     const pdfLocation = './forms/Data_Destruction_V1.0.pdf';
-    const existingPdfBytes = await fetch(pdfLocation).then(res => res.arrayBuffer());
-    const pdfConsentDoc = await PDFDocument.load(existingPdfBytes);
-    const helveticaFont = await pdfConsentDoc.embedFont(StandardFonts.TimesRomanItalic);
-    const pages = pdfConsentDoc.getPages();
-    for (let i = 0; i <= pages.length; i++) {seekLastPage = i}
-    const editPage = pages[seekLastPage-1];
     const currentTime = new Date(data[119449326]).toLocaleDateString();
+
     renderDownload(participantSignature, currentTime, pdfLocation, {x:150,y:420},{x1:150,y1:400},{x:155,y:380},20,15,20);
 }
 
@@ -520,11 +492,6 @@ const renderDownload = async (participant, timeStamp, fileLocation, nameCoordina
     // Serialize the PDFDocument to bytes (a Uint8Array)
     const pdfBytes = await pdfDoc.save();
 
-    if (isMobile) {
-      renderPdfBytesInNewTab(pdfBytes);
-      return;
-    }
-
     // Trigger the browser to download the PDF document
     download(pdfBytes, fileLocationDownload, "application/pdf");
 }
@@ -582,4 +549,106 @@ const consentSignTemplate = () => {
         </div>
     </form>
     `;
+}
+
+/**
+ * Generates a signed PDF file, and returns the URL of the file
+ * @param {object} data
+ * @param {'consent'| 'HIPAA'} fileType
+ * @returns Promise<string>
+ */
+async function generateSignedPdf(data, fileType) {
+  let sourcePdfLocation;
+  let coords;
+  let timeStamp;
+  const siteDict = siteAcronyms();
+  const participantSite = siteDict[data['827220437']];
+  const participantFullName = data[471168198] + ' ' + data[736251808];
+  const fontSize = {
+    nameSize: 24,
+    timeSize: 24,
+    signatureSize: 20,
+  };
+
+  if (fileType === 'consent') {
+    sourcePdfLocation = './forms/consent/' + data[454205108] + '.pdf';
+    timeStamp = new Date(data[454445267]).toLocaleDateString();
+    coords = signaturePosConsentJSON[participantSite];
+    if (!coords) {
+      coords = {
+        nameX: 110,
+        nameY: 400,
+        signatureX: 110,
+        signatureY: 330,
+        dateX: 110,
+        dateY: 370,
+      };
+    }
+  } else if (fileType === 'HIPAA') {
+    sourcePdfLocation = './forms/HIPAA/' + data[412000022] + '.pdf';
+    timeStamp = new Date(data[262613359]).toLocaleDateString();
+    coords = signaturePosJSON[participantSite];
+    if (!coords) {
+      coords = {
+        nameX: 200,
+        nameY: 275,
+        signatureX: 200,
+        signatureY: 225,
+        dateX: 200,
+        dateY: 325,
+      };
+    }
+  }
+
+  const sourcePdfBytes = await fetch(sourcePdfLocation).then((res) =>
+    res.arrayBuffer()
+  );
+  const pdfDoc = await PDFDocument.load(sourcePdfBytes);
+  const helveticaFont = await pdfDoc.embedFont(StandardFonts.TimesRomanItalic);
+  const pageArray = pdfDoc.getPages();
+  const pageToEdit = pageArray[pageArray.length - 1];
+
+  pageToEdit.drawText(participantFullName, {
+    x: coords.nameX,
+    y: coords.nameY,
+    size: fontSize.nameSize,
+  });
+  pageToEdit.drawText(timeStamp, {
+    x: coords.dateX,
+    y: coords.dateY,
+    size: fontSize.timeSize,
+  });
+  pageToEdit.drawText(participantFullName, {
+    x: coords.signatureX,
+    y: coords.signatureY,
+    size: fontSize.signatureSize,
+    font: helveticaFont,
+  });
+
+  const pdfBytes = await pdfDoc.save();
+  const blob = new Blob([pdfBytes], { type: 'application/pdf' });
+  const pdfUrl = URL.createObjectURL(blob);
+
+  return pdfUrl;
+}
+  
+/**
+ * 
+ * @param {object} data 
+ * @param {MouseEvent} evt mouse click event
+ * @returns 
+ */
+export async function handleSignedPdfDownload(data, evt) {
+  if (!evt.target.href) {
+    evt.preventDefault();
+    evt.target.href = await generateSignedPdf(data, evt.target.dataset.file);
+    evt.target.click();
+    return;
+  }
+
+  if (isMobile && evt.target.href) {
+    evt.preventDefault();
+    openNewTab(evt.target.href);
+    return;
+  }
 }

--- a/js/pages/agreements.js
+++ b/js/pages/agreements.js
@@ -1,4 +1,4 @@
-import { getMyData, hideAnimation, showAnimation, siteAcronyms, dateTime, storeResponse } from "../shared.js";
+import { getMyData, hideAnimation, showAnimation, siteAcronyms, dateTime, storeResponse, renderPdfBytesInNewTab, isMobile } from "../shared.js";
 import { initializeCanvas } from './consent.js'
 const { PDFDocument, StandardFonts } = PDFLib;
 
@@ -519,6 +519,11 @@ const renderDownload = async (participant, timeStamp, fileLocation, nameCoordina
     
     // Serialize the PDFDocument to bytes (a Uint8Array)
     const pdfBytes = await pdfDoc.save();
+
+    if (isMobile) {
+      renderPdfBytesInNewTab(pdfBytes);
+      return;
+    }
 
     // Trigger the browser to download the PDF document
     download(pdfBytes, fileLocationDownload, "application/pdf");

--- a/js/pages/consent.js
+++ b/js/pages/consent.js
@@ -802,21 +802,13 @@ const consentConsentPage = async () => {
     addEventConsentSubmit();
 }
 
-const initializeForm = (formName, containerName) =>{
-    let ob = document.getElementById(containerName);
-    ob.data = formName
-
-}
-
 export const consentFinishedPage = async () => {
     window.scrollTo(0, 0);
     const mainContent = document.getElementById('root');
     let template = renderProgress(10);
     const myData = await getMyData();
     let data = myData.data;
-    let siteDict = siteAcronyms();
-    let versionJSON = await fetch('./forms/Consent_versioning.json').then(res => res.json());
-    let participantSite = siteDict[myData.data['827220437']];
+
     template += `
     <div class="row">
         <div class="col-lg-2">
@@ -826,8 +818,8 @@ export const consentFinishedPage = async () => {
                 <h2>You have completed the consent process</h2>
             </div>
             <div style="margin-left:20px">
-                <div class="row"><div style="margin-left:20px"><i class="fas fa-file-download"></i> <a style="margin-left:10px" title="Download consent form" data-toggle="tooltip" id="consentDownload" download="signed_consent_form.pdf" data-file="signed-consent" >Download a copy of your signed consent form&nbsp</a></div></div>
-                <div class="row"><div style="margin-left:20px"><i class="fas fa-file-download"></i> <a style="margin-left:10px" title="Download health records release form" data-toggle="tooltip" id="healthRecordsDownload" download="signed_health_records_release_form.pdf" data-file="signed-HIPAA" >Download a copy of your signed health records release form&nbsp</a></div></div>
+                <div class="row"><div style="margin-left:20px"><i class="fas fa-file-download"></i> <a style="margin-left:10px" title="Download consent form" data-toggle="tooltip" id="consentDownload" download="signed_consent.pdf" data-file="signed-consent" >Download a copy of your signed consent form&nbsp</a></div></div>
+                <div class="row"><div style="margin-left:20px"><i class="fas fa-file-download"></i> <a style="margin-left:10px" title="Download health records release form" data-toggle="tooltip" id="healthRecordsDownload" download="signed_hipaa.pdf" data-file="signed-HIPAA" >Download a copy of your signed health records release form&nbsp</a></div></div>
             </div>
             
             <div>
@@ -845,17 +837,12 @@ export const consentFinishedPage = async () => {
         consentToProfilePage();
     })
 
-    document
-      .getElementById('consentDownload')
-      .addEventListener('click', async (e) => {
+    const anchorIdArray= ['consentDownload', 'healthRecordsDownload'];
+    for (const anchorId of anchorIdArray) {
+      document.getElementById(anchorId).addEventListener('click', async (e) => {
         await downloadSignedPdf(data, e);
       });
-
-    document
-      .getElementById('healthRecordsDownload')
-      .addEventListener('click', async (e) => {
-        await downloadSignedPdf(data, e);
-      });
+    }
 }
 
 export const consentToProfilePage = () => {

--- a/js/pages/consent.js
+++ b/js/pages/consent.js
@@ -1,4 +1,4 @@
-import { todaysDate, storeResponse, dataSavingBtn, dateTime, errorMessageConsent, siteAcronyms, getMyData, hideAnimation, showAnimation, isMobile } from "../shared.js";
+import { todaysDate, storeResponse, dataSavingBtn, dateTime, errorMessageConsent, siteAcronyms, getMyData, hideAnimation, showAnimation, isMobile, openNewTab } from "../shared.js";
 import { renderUserProfile } from "../components/form.js";
 import { removeAllErrors, addEventsConsentSign } from "../event.js";
 import { renderDownloadConsentCopy, renderDownloadHIPAA } from "./agreements.js";
@@ -786,16 +786,6 @@ const consentConsentPage = async () => {
         consentIndigenousPage();
     })
 
-    let urlToNewTabMap = {};
-
-    function openNewTab(url) {
-      if (!urlToNewTabMap[url] || urlToNewTabMap[url].closed) {
-        urlToNewTabMap[url] = window.open(url);
-      } else {
-        urlToNewTabMap[url].focus();
-      }
-    } 
-
     if (isMobile) {
         const anchorArray = document.querySelectorAll('a[data-file="consent-form"]');
         for (const anchor of anchorArray) {
@@ -854,11 +844,13 @@ export const consentFinishedPage = async () => {
     document.getElementById('toLeaving').addEventListener('click', () => {
         consentToProfilePage();
     })
-    document.getElementById('consentDownload').addEventListener('click', () => {
+    document.getElementById('consentDownload').addEventListener('click', (e) => {
         renderDownloadConsentCopy(data);
+        isMobile && e.preventDefault();
     });
-    document.getElementById('healthRecordsDownload').addEventListener('click', () => {
+    document.getElementById('healthRecordsDownload').addEventListener('click', (e) => {
         renderDownloadHIPAA(data);
+        isMobile && e.preventDefault();
     });
     
 

--- a/js/pages/consent.js
+++ b/js/pages/consent.js
@@ -1,7 +1,7 @@
-import { todaysDate, storeResponse, dataSavingBtn, dateTime, errorMessageConsent, siteAcronyms, getMyData, hideAnimation, showAnimation, isMobile, openNewTab } from "../shared.js";
+import { todaysDate, storeResponse, dataSavingBtn, dateTime, errorMessageConsent, siteAcronyms, getMyData, hideAnimation, showAnimation, isMobile, openNewTab} from "../shared.js";
 import { renderUserProfile } from "../components/form.js";
 import { removeAllErrors, addEventsConsentSign } from "../event.js";
-import { renderDownloadConsentCopy, renderDownloadHIPAA } from "./agreements.js";
+import { handleSignedPdfDownload } from "./agreements.js";
 
 export const consentTemplate = () => {
     consentWelcomePage();
@@ -826,8 +826,8 @@ export const consentFinishedPage = async () => {
                 <h2>You have completed the consent process</h2>
             </div>
             <div style="margin-left:20px">
-                <div class="row"><div style="margin-left:20px"><i class="fas fa-file-download"></i> <a style="margin-left:10px" type="button" title="Download consent form" data-toggle="tooltip" id="consentDownload">Download a copy of your signed consent form&nbsp</a></div></div>
-                <div class="row"><div style="margin-left:20px"><i class="fas fa-file-download"></i> <a style="margin-left:10px" type="button" title="Download health records release form" data-toggle="tooltip" id="healthRecordsDownload">Download a copy of your signed health records release form&nbsp</a></div></div>
+                <div class="row"><div style="margin-left:20px"><i class="fas fa-file-download"></i> <a style="margin-left:10px" title="Download consent form" data-toggle="tooltip" id="consentDownload" download="signed_consent_form.pdf" data-file="consent" >Download a copy of your signed consent form&nbsp</a></div></div>
+                <div class="row"><div style="margin-left:20px"><i class="fas fa-file-download"></i> <a style="margin-left:10px" title="Download health records release form" data-toggle="tooltip" id="healthRecordsDownload" download="signed_health_records_release_form.pdf" data-file="HIPAA" >Download a copy of your signed health records release form&nbsp</a></div></div>
             </div>
             
             <div>
@@ -844,16 +844,18 @@ export const consentFinishedPage = async () => {
     document.getElementById('toLeaving').addEventListener('click', () => {
         consentToProfilePage();
     })
-    document.getElementById('consentDownload').addEventListener('click', (e) => {
-        renderDownloadConsentCopy(data);
-        isMobile && e.preventDefault();
-    });
-    document.getElementById('healthRecordsDownload').addEventListener('click', (e) => {
-        renderDownloadHIPAA(data);
-        isMobile && e.preventDefault();
-    });
-    
 
+    document
+      .getElementById('consentDownload')
+      .addEventListener('click', async (e) => {
+        await handleSignedPdfDownload(data, e);
+      });
+
+    document
+      .getElementById('healthRecordsDownload')
+      .addEventListener('click', async (e) => {
+        await handleSignedPdfDownload(data, e);
+      });
 }
 
 export const consentToProfilePage = () => {

--- a/js/pages/consent.js
+++ b/js/pages/consent.js
@@ -1,7 +1,7 @@
 import { todaysDate, storeResponse, dataSavingBtn, dateTime, errorMessageConsent, siteAcronyms, getMyData, hideAnimation, showAnimation, isMobile, openNewTab} from "../shared.js";
 import { renderUserProfile } from "../components/form.js";
 import { removeAllErrors, addEventsConsentSign } from "../event.js";
-import { handleSignedPdfDownload } from "./agreements.js";
+import { downloadSignedPdf } from "./agreements.js";
 
 export const consentTemplate = () => {
     consentWelcomePage();
@@ -611,7 +611,7 @@ const consentConsentPage = async () => {
                 <iframe id="pdfIframeContainer" src="${'./forms/consent/'  + participantSite + '_Consent_' + versionJSON[participantSite]['Consent'] + '.html'}" style="width:100%; height:500px; overflow:scroll;" frameborder="1px"><span class="loader">Please wait...</span></iframe>
                 <!--<object id="pdfContainer" data="https://storage.googleapis.com/myconnect_app_stage/forms/consent/HP_Consent_V1.0.pdf" style="height:500px; width:100%"></object>-->
                 <!--</div>-->
-                <div class="row"style="margin:auto"><div style="margin:auto"><a href="${'./forms/consent/'  + participantSite + '_Consent_' + versionJSON[participantSite]['Consent'] + '.pdf'}" title="Download consent form" data-toggle="tooltip" download="connect_consent.pdf" class="consentBodyFont2" data-file="consent-form"> Download an unsigned copy of the informed consent form&nbsp<i class="fas fa-file-download"></i></a></div></div>
+                <div class="row"style="margin:auto"><div style="margin:auto"><a href="${'./forms/consent/'  + participantSite + '_Consent_' + versionJSON[participantSite]['Consent'] + '.pdf'}" title="Download consent form" data-toggle="tooltip" download="connect_consent.pdf" class="consentBodyFont2" data-file="unsigned-form"> Download an unsigned copy of the informed consent form&nbsp<i class="fas fa-file-download"></i></a></div></div>
                 
                 <h4 class="consentSubheader" style="margin-top:50px">Electronic health records release (HIPAA Authorization) form</h4>
                 <p class="consentBodyFont2" style="text-indent:40px">This allows Connect to access your electronic health records.</p>
@@ -627,7 +627,7 @@ const consentConsentPage = async () => {
                 <iframe id="pdfIframeContainer1" src="${'./forms/HIPAA/'  + participantSite + '_HIPAA_' + versionJSON[participantSite]['HIPAA'] + '.html'}" style="width:100%; height:500px; overflow:scroll;" frameborder="1px"><span class="loader">Please wait...</span></iframe>
                 <!--<object id="pdfContainer1" style="height:500px; width:100%"></object>-->
                 <!--</div>-->
-                <div class="row" style="margin:auto"><div style="margin:auto"><a href="${'./forms/HIPAA/'  + participantSite + '_HIPAA_' + versionJSON[participantSite]['HIPAA'] + '.pdf'}" title="Download health records release form" data-toggle="tooltip" download="connect_hipaa.pdf" class="consentBodyFont2" data-file="consent-form">Download an unsigned copy of the release form&nbsp<i class="fas fa-file-download"></i></a></div></div>
+                <div class="row" style="margin:auto"><div style="margin:auto"><a href="${'./forms/HIPAA/'  + participantSite + '_HIPAA_' + versionJSON[participantSite]['HIPAA'] + '.pdf'}" title="Download health records release form" data-toggle="tooltip" download="connect_hipaa.pdf" class="consentBodyFont2" data-file="unsigned-form">Download an unsigned copy of the release form&nbsp<i class="fas fa-file-download"></i></a></div></div>
                 
                 
                 <p class="consentBodyFont2" style="margin-top:50px">By clicking “Yes, I agree to join Connect” and typing your name, you confirm the following:</p>
@@ -787,7 +787,7 @@ const consentConsentPage = async () => {
     })
 
     if (isMobile) {
-        const anchorArray = document.querySelectorAll('a[data-file="consent-form"]');
+        const anchorArray = document.querySelectorAll('a[data-file="unsigned-form"]');
         for (const anchor of anchorArray) {
           anchor.addEventListener(
             "click",
@@ -826,8 +826,8 @@ export const consentFinishedPage = async () => {
                 <h2>You have completed the consent process</h2>
             </div>
             <div style="margin-left:20px">
-                <div class="row"><div style="margin-left:20px"><i class="fas fa-file-download"></i> <a style="margin-left:10px" title="Download consent form" data-toggle="tooltip" id="consentDownload" download="signed_consent_form.pdf" data-file="consent" >Download a copy of your signed consent form&nbsp</a></div></div>
-                <div class="row"><div style="margin-left:20px"><i class="fas fa-file-download"></i> <a style="margin-left:10px" title="Download health records release form" data-toggle="tooltip" id="healthRecordsDownload" download="signed_health_records_release_form.pdf" data-file="HIPAA" >Download a copy of your signed health records release form&nbsp</a></div></div>
+                <div class="row"><div style="margin-left:20px"><i class="fas fa-file-download"></i> <a style="margin-left:10px" title="Download consent form" data-toggle="tooltip" id="consentDownload" download="signed_consent_form.pdf" data-file="signed-consent" >Download a copy of your signed consent form&nbsp</a></div></div>
+                <div class="row"><div style="margin-left:20px"><i class="fas fa-file-download"></i> <a style="margin-left:10px" title="Download health records release form" data-toggle="tooltip" id="healthRecordsDownload" download="signed_health_records_release_form.pdf" data-file="signed-HIPAA" >Download a copy of your signed health records release form&nbsp</a></div></div>
             </div>
             
             <div>
@@ -848,13 +848,13 @@ export const consentFinishedPage = async () => {
     document
       .getElementById('consentDownload')
       .addEventListener('click', async (e) => {
-        await handleSignedPdfDownload(data, e);
+        await downloadSignedPdf(data, e);
       });
 
     document
       .getElementById('healthRecordsDownload')
       .addEventListener('click', async (e) => {
-        await handleSignedPdfDownload(data, e);
+        await downloadSignedPdf(data, e);
       });
 }
 

--- a/js/shared.js
+++ b/js/shared.js
@@ -1214,5 +1214,3 @@ export function openNewTab(url) {
     urlToNewTabMap[url].focus();
   }
 } 
-
-

--- a/js/shared.js
+++ b/js/shared.js
@@ -1177,27 +1177,27 @@ export async function elementIsLoaded(selector, timeout = 1000) {
  * @returns {boolean}
  */
 function checkDeviceMobile() {
-    let isMobile = false;
-  
-    if ('maxTouchPoints' in navigator) {
-      isMobile = navigator.maxTouchPoints > 0;
-    } else if ('msMaxTouchPoints' in navigator) {
-      isMobile = navigator.msMaxTouchPoints > 0;
+  let isMobile = false;
+
+  if ('maxTouchPoints' in navigator) {
+    isMobile = navigator.maxTouchPoints > 0;
+  } else if ('msMaxTouchPoints' in navigator) {
+    isMobile = navigator.msMaxTouchPoints > 0;
+  } else {
+    const mediaQuery = matchMedia?.('(pointer:coarse)');
+    if (mediaQuery?.media === '(pointer:coarse)') {
+      isMobile = !!mediaQuery.matches;
+    } else if ('orientation' in window) {
+      isMobile = true;
     } else {
-      const mediaQuery = matchMedia?.('(pointer:coarse)');
-      if (mediaQuery?.media === '(pointer:coarse)') {
-        isMobile = !!mediaQuery.matches;
-      } else if ('orientation' in window) {
-        isMobile = true;
-      } else {
-        isMobile = /Mobi|Android|Tablet|iPad|iPhone|iPod|webOS/i.test(
-          navigator.userAgent
-        );
-      }
+      isMobile = /Mobi|Android|Tablet|iPad|iPhone|iPod|webOS/i.test(
+        navigator.userAgent
+      );
     }
-  
-    return isMobile;
   }
+
+  return isMobile;
+}
   
 export const isMobile = checkDeviceMobile();
 

--- a/js/shared.js
+++ b/js/shared.js
@@ -1215,13 +1215,4 @@ export function openNewTab(url) {
   }
 } 
 
-/**
- * Render PDF bytes to a PDF file in new tab
- * @param {Uint8Array} pdfBytes
- */
-export function renderPdfBytesInNewTab(pdfBytes) {
-  const blob = new Blob([pdfBytes], { type: 'application/pdf' });
-  const pdfUrl = URL.createObjectURL(blob);
 
-  openNewTab(pdfUrl);
-}

--- a/js/shared.js
+++ b/js/shared.js
@@ -1200,3 +1200,28 @@ export async function elementIsLoaded(selector, timeout = 1000) {
 
   return document.querySelector(selector);
 }
+
+let urlToNewTabMap = {};
+
+/**
+ * Open file in new tab
+ * @param {string} url 
+ */
+export function openNewTab(url) {
+  if (!urlToNewTabMap[url] || urlToNewTabMap[url].closed) {
+    urlToNewTabMap[url] = window.open(url);
+  } else {
+    urlToNewTabMap[url].focus();
+  }
+} 
+
+/**
+ * Render PDF bytes to a PDF file in new tab
+ * @param {Uint8Array} pdfBytes
+ */
+export function renderPdfBytesInNewTab(pdfBytes) {
+  const blob = new Blob([pdfBytes], { type: 'application/pdf' });
+  const pdfUrl = URL.createObjectURL(blob);
+
+  openNewTab(pdfUrl);
+}

--- a/js/shared.js
+++ b/js/shared.js
@@ -1156,35 +1156,6 @@ return urlSearchStr
 }
 
 /**
- * Check if current device is a mobile device (smartphone, tablet, or others with touch screen)
- * @returns {boolean}
- */
-function checkDeviceMobile() {
-  let isMobile = false;
-
-  if ('maxTouchPoints' in navigator) {
-    isMobile = navigator.maxTouchPoints > 0;
-  } else if ('msMaxTouchPoints' in navigator) {
-    isMobile = navigator.msMaxTouchPoints > 0;
-  } else {
-    const mediaQuery = matchMedia?.('(pointer:coarse)');
-    if (mediaQuery?.media === '(pointer:coarse)') {
-      isMobile = !!mediaQuery.matches;
-    } else if ('orientation' in window) {
-      isMobile = true;
-    } else {
-      isMobile = /Mobi|Android|Tablet|iPad|iPhone|iPod|webOS/i.test(
-        navigator.userAgent
-      );
-    }
-  }
-
-  return isMobile;
-}
-
-export const isMobile = checkDeviceMobile();
-
-/**
  * Wait for an element to be loaded, with a default timeout.
  * @param {string} selector
  * @param {number} timeout
@@ -1200,6 +1171,35 @@ export async function elementIsLoaded(selector, timeout = 1000) {
 
   return document.querySelector(selector);
 }
+
+/**
+ * Check if current device is a mobile device (smartphone, tablet, or others with touch screen)
+ * @returns {boolean}
+ */
+function checkDeviceMobile() {
+    let isMobile = false;
+  
+    if ('maxTouchPoints' in navigator) {
+      isMobile = navigator.maxTouchPoints > 0;
+    } else if ('msMaxTouchPoints' in navigator) {
+      isMobile = navigator.msMaxTouchPoints > 0;
+    } else {
+      const mediaQuery = matchMedia?.('(pointer:coarse)');
+      if (mediaQuery?.media === '(pointer:coarse)') {
+        isMobile = !!mediaQuery.matches;
+      } else if ('orientation' in window) {
+        isMobile = true;
+      } else {
+        isMobile = /Mobi|Android|Tablet|iPad|iPhone|iPod|webOS/i.test(
+          navigator.userAgent
+        );
+      }
+    }
+  
+    return isMobile;
+  }
+  
+export const isMobile = checkDeviceMobile();
 
 let urlToNewTabMap = {};
 


### PR DESCRIPTION
This PR is to update previous implementation for issue [#98](https://github.com/episphere/connectApp/issues/98), to handle downloading of signed forms in mobile devices. Two new functions(`generateSignedPdf` and `downloadSignedPdf`) were added.