### PR TITLE
#635 - connectApp segment - user profile archiving

### DIFF
--- a/js/pages/settings.js
+++ b/js/pages/settings.js
@@ -45,6 +45,7 @@ let additionalEmailRow;
  * if data exists and profile has been submitted, then render the user's data
  * if data exists and profile is verified, then render the user's data and edit functionality
  */
+
 export const renderSettingsPage = async () => {
   document.title = 'My Connect - My Profile';
   showAnimation();
@@ -76,32 +77,32 @@ export const renderSettingsPage = async () => {
                 <div class="col-lg-3">
                 </div>
                 <div class="col-lg-6" id="myProfileHeader">
-                    <p id="pendingVerification" style="color:#1c5d86">
-                        Thank you for joining the National Cancer Institute's Connect for Cancer Prevention Study. Your involvement is very important.
-                        We are currently verifying your profile, which may take up to 3 business days.
-                        <br>
+                    <p id="pendingVerification" style="color:#1c5d86; display:none;">
+                    Thank you for joining the National Cancer Institute's Connect for Cancer Prevention Study. Your involvement is very important.
+                    We are currently verifying your profile, which may take up to 3 business days.
+                    <br>
                     </p>
-                    <p class="consentHeadersFont" style="color:#606060">
+                    <p class="consentHeadersFont" id="myProfileTextContainer" style="color:#606060; display:none;">
                         My Profile
                     </p>
-                    
-                    <div class="userProfileBox">
+                
+                    <div class="userProfileBox" id="nameDiv" style="display:none">
                         ${renderNameHeadingAndButton()}
                         ${renderUserNameData(userData)}
                         ${renderChangeNameGroup(userData)} 
                     </div>
-                    <div class="userProfileBox">
+                    <div class="userProfileBox" id="contactInformationDiv" style="display:none">
                         ${renderContactInformationHeadingAndButton()}
                         ${renderContactInformationData(userData, canWeVoicemailMobile, canWeText, canWeVoicemailHome, canWeVoicemailOther)}
                         ${renderChangeContactInformationGroup(userData)}
                     </div>    
                         
-                    <div class="userProfileBox">
+                    <div class="userProfileBox" id="mailingAddressDiv" style="display:none">
                         ${renderMailingAddressHeadingAndButton()}
                         ${renderMailingAddressData(userData)}
                         ${renderChangeMailingAddressGroup(1)}
                     </div>
-                    <div class="userProfileBox">
+                    <div class="userProfileBox" id="signInInformationDiv" style="display:none">
                         ${renderSignInInformationHeadingAndButton()}
                         ${renderSignInInformationData(userData)}
                         ${renderChangeSignInInformationGroup(userData)}
@@ -110,12 +111,13 @@ export const renderSettingsPage = async () => {
                 <div class="col-lg-3">
                 </div>
             </div>
-                `;
+                `;  
     } else {
       template += `${profileIsIncomplete()}`;
     }
-
-    buildPageTemplate();
+    
+    buildPageTemplate();  
+      
 
     /**
      * If the user profile has been verified, then show the profile and edit functionality:
@@ -138,14 +140,23 @@ export const renderSettingsPage = async () => {
 
 const buildPageTemplate = () => {
   document.getElementById('root').innerHTML = template;
-  hideAnimation();
-  togglePendingVerificationMessage(userData);
   if (userData[cId.userProfileSubmittedAutogen] === cId.yes) {
-    loadNameElements();
-    loadContactInformationElements();
-    loadMailingAddressElements();
-    loadSignInInformationElements();
+      loadNameElements();
+      loadContactInformationElements();
+      loadMailingAddressElements();
+      loadSignInInformationElements();
+      showFormElements();
+      togglePendingVerificationMessage(userData);
   }
+  hideAnimation();
+};
+
+const showFormElements = () => {
+  document.getElementById('myProfileTextContainer').style.display = 'block';
+  document.getElementById('nameDiv').style.display = 'block';
+  document.getElementById('contactInformationDiv').style.display = 'block';
+  document.getElementById('mailingAddressDiv').style.display = 'block';
+  document.getElementById('signInInformationDiv').style.display = 'block';
 };
 
 /**
@@ -209,6 +220,7 @@ const submitNewName = async (firstName, lastName) => {
     successMessageElement.style.display = 'block';
     document.getElementById('profileFirstName').textContent = firstName;
     document.getElementById('profileLastName').textContent = lastName;
+    refreshUserDataAfterEdit();
   }
 };
 
@@ -249,7 +261,7 @@ const handleEditContactInformationSection = () => {
       toggleActiveForm(FormTypes.CONTACT);
     }
     toggleButtonText();
-    handleContactInformationRadioButtonPresets(canWeVoicemailMobile, canWeText, canWeVoicemailHome, canWeVoicemailOther);
+    handleContactInformationRadioButtonPresets(mobilePhoneNumberComplete, canWeVoicemailMobile, canWeText, homePhoneNumberComplete, canWeVoicemailHome, otherPhoneNumberComplete, canWeVoicemailOther);
     updatePhoneNumberInputFocus();
   });
 
@@ -301,6 +313,7 @@ const submitNewContactInformation = async preferredEmail => {
     successMessageElement = document.getElementById('changeContactInformationSuccess');
     successMessageElement.style.display = 'block';
     document.getElementById('profilePreferredEmail').textContent = preferredEmail;
+    refreshUserDataAfterEdit();
   }
 };
 
@@ -358,6 +371,7 @@ const submitNewMailingAddress = async (addressLine1, addressLine2, city, state, 
     }
     successMessageElement = document.getElementById('mailingAddressSuccess');
     successMessageElement.style.display = 'block';
+    refreshUserDataAfterEdit();
   }
 };
 
@@ -398,6 +412,7 @@ const submitNewEmailAddress = async email => {
     document.getElementById('profileEmailAddress').textContent = email;
     successMessageElement = document.getElementById('emailSuccess');
     successMessageElement.style.display = 'block';
+    refreshUserDataAfterEdit();
   }
 };
 
@@ -435,6 +450,13 @@ const toggleButtonText = () => {
   changeEmailButton.textContent = isEmailFormDisplayed ? 'Cancel' : 'Update Email Address';
 };
 
+const refreshUserDataAfterEdit = async () => {
+  const updatedUserData = await getMyData();
+  if (updatedUserData.code === 200) {
+    userData = updatedUserData.data;
+  }
+};
+
 /**
  * Start: HTML rendering functions
  */
@@ -468,7 +490,7 @@ export const renderUserNameData = userData => {
       ${
         userData[cId.fName]
           ? `
-          <div class="row userProfileLinePaddings" id="firstNameRow" >
+          <div class="row userProfileLinePaddings" id="firstNameRow">
               <div class="col">
                   <span class="userProfileBodyFonts">
                       First Name

--- a/js/settingsHelpers.js
+++ b/js/settingsHelpers.js
@@ -80,7 +80,7 @@ const updateElementContentAndDisplay = (element, text, content, display) => {
 };
 
 export const showAndPushElementToArrayIfExists = (value, element, isParentTruthy, array) => {
-  if (value !== null && value !== '' && element && isParentTruthy) {
+  if (value != null && value !== '' && element && isParentTruthy) {
     element.style.display = 'block';
     array.push(element);
   }
@@ -94,15 +94,21 @@ export const hideOptionalElementsOnShowForm = elementsArray => {
   });
 };
 
-export const handleContactInformationRadioButtonPresets = (canWeVoicemailMobile, canWeText, canWeVoicemailHome, canWeVoicemailOther) => {
-  document.getElementById('mobileVoicemailPermissionYesRadio').checked = canWeVoicemailMobile;
-  document.getElementById('mobileVoicemailPermissionNoRadio').checked = !canWeVoicemailMobile;
-  document.getElementById('textPermissionYesRadio').checked = canWeText;
-  document.getElementById('textPermissionNoRadio').checked = !canWeText;
-  document.getElementById('homeVoicemailPermissionYesRadio').checked = canWeVoicemailHome;
-  document.getElementById('homeVoicemailPermissionNoRadio').checked = !canWeVoicemailHome;
-  document.getElementById('otherVoicemailPermissionYesRadio').checked = canWeVoicemailOther;
-  document.getElementById('otherVoicemailPermissionNoRadio').checked = !canWeVoicemailOther;
+export const handleContactInformationRadioButtonPresets = (mobilePhoneNumberComplete, canWeVoicemailMobile, canWeText, homePhoneNumberComplete, canWeVoicemailHome, otherPhoneNumberComplete, canWeVoicemailOther) => {
+  if (mobilePhoneNumberComplete) {
+    document.getElementById('mobileVoicemailPermissionYesRadio').checked = canWeVoicemailMobile;
+    document.getElementById('mobileVoicemailPermissionNoRadio').checked = !canWeVoicemailMobile;
+    document.getElementById('textPermissionYesRadio').checked = canWeText;
+    document.getElementById('textPermissionNoRadio').checked = !canWeText;
+  }
+  if (homePhoneNumberComplete) {
+    document.getElementById('homeVoicemailPermissionYesRadio').checked = canWeVoicemailHome;
+    document.getElementById('homeVoicemailPermissionNoRadio').checked = !canWeVoicemailHome;
+  }
+  if (otherPhoneNumberComplete) {
+    document.getElementById('otherVoicemailPermissionYesRadio').checked = canWeVoicemailOther;
+    document.getElementById('otherVoicemailPermissionNoRadio').checked = !canWeVoicemailOther;
+  }
 };
 
 export const FormTypes = {
@@ -299,7 +305,7 @@ export const changeName = async (firstName, lastName, middleName, suffix, prefer
   };
 
   const { changedUserDataForProfile, changedUserDataForHistory } = findChangedUserDataValues(newValues, userData);
-  const isSuccess = await processUserDataUpdate(changedUserDataForProfile, changedUserDataForHistory, userData[cId.userProfileHistory], 'changeName', false);
+  const isSuccess = processUserDataUpdate(changedUserDataForProfile, changedUserDataForHistory, userData[cId.userProfileHistory], 'changeName');
   return isSuccess;
 };
 
@@ -307,10 +313,16 @@ export const changeContactInformation = async (mobilePhoneNumberComplete, homePh
   document.getElementById('changeContactInformationFail').style.display = 'none';
   document.getElementById('changeContactInformationGroup').style.display = 'none';
 
-  canWeVoicemailMobile = mobilePhoneNumberComplete && canWeVoicemailMobile === cId.yes ? cId.yes : cId.no;
-  canWeText = mobilePhoneNumberComplete && canWeText === cId.yes ? cId.yes : cId.no;
-  canWeVoicemailHome = homePhoneNumberComplete && canWeVoicemailHome === cId.yes ? cId.yes : cId.no;
-  canWeVoicemailOther = otherPhoneNumberComplete && canWeVoicemailOther === cId.yes ? cId.yes : cId.no;
+  if (mobilePhoneNumberComplete) {
+    canWeVoicemailMobile = canWeVoicemailMobile ?? cId.no;
+    canWeText = canWeText ?? cId.no;
+  }
+  if (homePhoneNumberComplete) {
+    canWeVoicemailHome = canWeVoicemailHome ?? cId.no;
+  }
+  if (otherPhoneNumberComplete) {
+    canWeVoicemailOther = canWeVoicemailOther ?? cId.no;
+  }
 
   const newValues = {
     [cId.cellPhone]: mobilePhoneNumberComplete,
@@ -324,8 +336,8 @@ export const changeContactInformation = async (mobilePhoneNumberComplete, homePh
     [cId.additionalEmail]: additionalEmail,
   };
 
-  const { changedUserDataForProfile, changedUserDataForHistory } = findChangedUserDataValues(newValues, userData);
-  const isSuccess = await processUserDataUpdate(changedUserDataForProfile, changedUserDataForHistory, userData[cId.userProfileHistory], 'changeContactInformation', false);
+  const { changedUserDataForProfile, changedUserDataForHistory } = findChangedUserDataValues(newValues, userData, 'changeContactInformation');
+  const isSuccess = processUserDataUpdate(changedUserDataForProfile, changedUserDataForHistory, userData[cId.userProfileHistory], 'changeContactInformation');
   return isSuccess;
 };
 
@@ -342,7 +354,7 @@ export const changeMailingAddress = async (addressLine1, addressLine2, city, sta
   };
 
   const { changedUserDataForProfile, changedUserDataForHistory } = findChangedUserDataValues(newValues, userData);
-  const isSuccess = await processUserDataUpdate(changedUserDataForProfile, changedUserDataForHistory, userData[cId.userProfileHistory], 'mailingAddress', false);
+  const isSuccess = processUserDataUpdate(changedUserDataForProfile, changedUserDataForHistory, userData[cId.userProfileHistory], 'mailingAddress');
   return isSuccess;
 };
 
@@ -376,46 +388,65 @@ export const changeEmail = async (email, userData) => {
   };
 
   const { changedUserDataForProfile, changedUserDataForHistory } = findChangedUserDataValues(newValues, userData);
-  const isSuccess = await processUserDataUpdate(changedUserDataForProfile, changedUserDataForHistory, userData[cId.userProfileHistory], 'email', false);
+  const isSuccess = processUserDataUpdate(changedUserDataForProfile, changedUserDataForHistory, userData[cId.userProfileHistory], 'email');
   return isSuccess;
 };
 
 /**
  * Iterate the new values, compare them to existing values, and return the changed values.
+ * write an empty string to firestore if the history value is null/undefined/empty --per spec on 05-09-2023
+ * write an empty string ti firestore if the profile value is null/undefined/empty --per spec on 05-09-2023
  * @param {object} newUserData - the newly entered form fields
  * @param {object} existingUserData - the existing user profile data
  * @returns {changedUserDataForProfile, changedUserDataForHistory} - parallel objects containing the changed values
- */
-const findChangedUserDataValues = (newUserData, existingUserData) => {
+ * Contact information requires special handling because of the radio buttons
+ *   if the user is changing their cell phone number, we need to update the canWeVoicemailMobile and canWeText values
+ *   the same is true for homePhone and otherPhone (canWeVoicemailHome and canWeVoicemailOther)
+ *   if user deletes a number, set canWeVoicemail and canWeText to '' (empty string) --per spec on 05-09-2023
+ *   if user updates a number, ensure the canWeVoicemail and canWeText values are set
+*/
+const findChangedUserDataValues = (newUserData, existingUserData, type) => {
   const changedUserDataForProfile = {};
   const changedUserDataForHistory = {};
-
   Object.keys(newUserData).forEach(key => {
     if (newUserData[key] !== existingUserData[key]) {
-      changedUserDataForProfile[key] = newUserData[key];
-      changedUserDataForHistory[key] = existingUserData[key] ? existingUserData[key] : 'previously_empty';
+      changedUserDataForProfile[key] = newUserData[key] ?? '';
+      changedUserDataForHistory[key] = existingUserData[key] ?? '';
     }
+  });
 
-    //account for voicemail and text preferences in history when new phone number is added
-    //this forces save of previous preferences to history, attached to the phone number change
+  if (type === 'changeContactInformation') {
+
     if (cId.cellPhone in changedUserDataForProfile) {
-      changedUserDataForProfile[cId.canWeVoicemailMobile] = newUserData[cId.canWeVoicemailMobile] ? newUserData[cId.canWeVoicemailMobile] : cId.no;
-      changedUserDataForHistory[cId.canWeVoicemailMobile] = existingUserData[cId.canWeVoicemailMobile] ? existingUserData[cId.canWeVoicemailMobile] : cId.no;
-      changedUserDataForProfile[cId.canWeText] = newUserData[cId.canWeText] ? newUserData[cId.canWeText] : cId.no;
-      changedUserDataForHistory[cId.canWeText] = existingUserData[cId.canWeText] ? existingUserData[cId.canWeText] : cId.no;
+        if (!newUserData[cId.cellPhone]) {
+          changedUserDataForProfile[cId.canWeVoicemailMobile] = '';
+          changedUserDataForProfile[cId.canWeText] = '';
+        } else {
+          changedUserDataForProfile[cId.canWeVoicemailMobile] = newUserData[cId.canWeVoicemailMobile] ?? cId.no;
+          changedUserDataForProfile[cId.canWeText] = newUserData[cId.canWeText] ?? cId.no;
+        }
+        changedUserDataForHistory[cId.canWeVoicemailMobile] = existingUserData[cId.canWeVoicemailMobile] ?? cId.no;
+        changedUserDataForHistory[cId.canWeText] = existingUserData[cId.canWeText] ?? cId.no;
     }
 
     if (cId.homePhone in changedUserDataForProfile) {
-      changedUserDataForProfile[cId.canWeVoicemailHome] = newUserData[cId.canWeVoicemailHome] ? newUserData[cId.canWeVoicemailHome] : cId.no;
-      changedUserDataForHistory[cId.canWeVoicemailHome] = existingUserData[cId.canWeVoicemailHome] ? existingUserData[cId.canWeVoicemailHome] : cId.no;
+      if (!newUserData[cId.homePhone]) {
+        changedUserDataForProfile[cId.canWeVoicemailHome] = '';
+      } else {
+        changedUserDataForProfile[cId.canWeVoicemailHome] = newUserData[cId.canWeVoicemailHome] ?? cId.no;
+      }
+      changedUserDataForHistory[cId.canWeVoicemailHome] = existingUserData[cId.canWeVoicemailHome] ?? cId.no;
     }
 
     if (cId.otherPhone in changedUserDataForProfile) {
-      changedUserDataForProfile[cId.canWeVoicemailOther] = newUserData[cId.canWeVoicemailOther] ? newUserData[cId.canWeVoicemailOther] : cId.no;
-      changedUserDataForHistory[cId.canWeVoicemailOther] = existingUserData[cId.canWeVoicemailOther] ? existingUserData[cId.canWeVoicemailOther] : cId.no;
+      if (!newUserData[cId.otherPhone]) {
+        changedUserDataForProfile[cId.canWeVoicemailOther] = '';
+      } else {
+        changedUserDataForProfile[cId.canWeVoicemailOther] = newUserData[cId.canWeVoicemailOther] ?? cId.no;
+      }
+      changedUserDataForHistory[cId.canWeVoicemailOther] = existingUserData[cId.canWeVoicemailOther] ?? cId.no;
     }
-
-  });
+  }
 
   return { changedUserDataForProfile, changedUserDataForHistory };
 };
@@ -426,12 +457,11 @@ const findChangedUserDataValues = (newUserData, existingUserData) => {
  * @param {object} changedUserDataForHistory  - the previous values to be written to history.
  * @param {object} userHistory - the user's existing history
  * @param {string} type - the type of data being changed (e.g. name, contact info, mailing address, log-in email)
- * @param {*} isProfile
  * @returns {boolean} - whether the write operation was successful to control the UI messaging
  */
-const processUserDataUpdate = async (changedUserDataForProfile, changedUserDataForHistory, userHistory, type, isProfile) => {
+const processUserDataUpdate = async (changedUserDataForProfile, changedUserDataForHistory, userHistory, type) => {
   if (changedUserDataForProfile && Object.keys(changedUserDataForProfile).length !== 0) {
-    changedUserDataForProfile[cId.userProfileHistory] = updateUserHistory(changedUserDataForProfile, changedUserDataForHistory, userHistory, false);
+    changedUserDataForProfile[cId.userProfileHistory] = updateUserHistory(changedUserDataForHistory, userHistory);
     //console.log('changedUserData', changedUserDataForProfile);
 
     await storeResponse(changedUserDataForProfile)
@@ -443,77 +473,74 @@ const processUserDataUpdate = async (changedUserDataForProfile, changedUserDataF
     return true;
   } else {
     document.getElementById(`${type}Fail`).style.display = 'block';
-    document.getElementById(`${type}Error`).innerHTML = 'No changes were made. If you meant to update your existing information, please make a change and try again.';
+    document.getElementById(`${type}Error`).innerHTML = 'This is the information we already have. If you meant to update your existing information, please make a change and try again.';
     return false;
   }
 };
 
-//TODO work in progress pending data model changes. This description may not be accurate yet. No history writes are happening on initial signup (05/08/2023 JA)
 /**
  * Update the user's history based on new data entered by the user. Prepari it for POST to user's proifle in firestore
- * @param {array of objects} newDataToWrite - the new data update (changed data only) entered by the user
+ * This routine runs once per form submission.
+ * First, check for user history and add it to the userProfileHistoryArray
+ * Next, create a new map of the user's changes and add it to the userProfileHistoryArray with a timestamp
  * @param {array of objects} existingDataToUpdate - the existingData to write to history (parallel data structure to newDataToWrite)
  * @param {array of objects} userHistory - the user's existing history
- * @param {boolean} isInitialSignup - is this the initial signup?
  * @returns {userProfileHistoryArray} -the array of objects to write to user profile history, with the new data added to the end of the array
- * This routine runs once per form submission.
- * First, check for user history
- * if it's the initial signup, or history is null, or history is empty, create user history based on current data.
- *     This is the original history and needs to be the first map in the array.
- *     This logic is included because the study already has active users prior to implementing the user history feature.
- * if isInitialSignup, stop after creating the initial history. There are no more updates to process.
- * if !isInitialSignup, process the user's changes after checking (and creating if necessary) the user's initial history.
- *     Add the user's update as a new map at the end of the user history array and include a timestamp
  */
-
-//TODO work in progress pending data design decisions - don't delete commented out code yet
-const updateUserHistory = (newDataToWrite, existingDataToUpdate, userHistory, isInitialSignup) => {
+const updateUserHistory = (existingDataToUpdate, userHistory) => {
   const userProfileHistoryArray = [];
-  // if (isInitialSignup || !currentUserHistory || Object.keys(currentUserHistory).length === 0) {
-  //     console.log('CurrentUserHistoryIsEmpty');
-  //     const initialUserHistoryMap = populateUserHistoryMap(newData, existingData, isInitialSignup);
-  //     userProfileHistoryArray.push(initialUserHistoryMap);
-  // }
-  if (!isInitialSignup) {
-    //userProfileHistoryArray.push({1:1, 2:2, 3:3});
-    if (userHistory && Object.keys(userHistory).length > 0) userProfileHistoryArray.push(...userHistory);
 
-    const newUserHistoryMap = populateUserHistoryMap(newDataToWrite, existingDataToUpdate, isInitialSignup);
-    userProfileHistoryArray.push(newUserHistoryMap);
-  }
+  if (userHistory && Object.keys(userHistory).length > 0) userProfileHistoryArray.push(...userHistory);
+  
+  const newUserHistoryMap = populateUserHistoryMap(existingDataToUpdate);
+  userProfileHistoryArray.push(newUserHistoryMap);
+
   return userProfileHistoryArray;
 };
 
-const populateUserHistoryMap = (newData, existingData, isInitialSignup) => {
+const populateUserHistoryMap = (existingData) => {
   const userHistoryMap = {};
-  if (existingData[cId.fName]) userHistoryMap[cId.fName] = isInitialSignup ? newData[cId.fName] : existingData[cId.fName];
-  if (existingData[cId.mName]) userHistoryMap[cId.mName] = isInitialSignup ? newData[cId.mName] : existingData[cId.mName];
-  if (existingData[cId.lName]) userHistoryMap[cId.lName] = isInitialSignup ? newData[cId.lName] : existingData[cId.lName];
-  if (existingData[cId.suffix]) userHistoryMap[cId.suffix] = isInitialSignup ? newData[cId.suffix] : existingData[cId.suffix];
-  if (existingData[cId.prefName]) userHistoryMap[cId.prefName] = isInitialSignup ? newData[cId.prefName] : existingData[cId.prefName];
-  if (existingData[cId.cellPhone]) {
-    userHistoryMap[cId.cellPhone] = isInitialSignup ? newData[cId.cellPhone] : existingData[cId.cellPhone];
-    userHistoryMap[cId.canWeVoicemailMobile] = isInitialSignup ? newData[cId.canWeVoicemailMobile] : existingData[cId.canWeVoicemailMobile];
-    userHistoryMap[cId.canWeText] = isInitialSignup ? newData[cId.canWeText] : existingData[cId.canWeText];
-  }
-  if (existingData[cId.homePhone]) {
-    userHistoryMap[cId.homePhone] = isInitialSignup ? newData[cId.homePhone] : existingData[cId.homePhone];
-    userHistoryMap[cId.canWeVoicemailHome] = isInitialSignup ? newData[cId.canWeVoicemailHome] : existingData[cId.canWeVoicemailHome];
-  }
-  if (existingData[cId.otherPhone]) {
-    userHistoryMap[cId.otherPhone] = isInitialSignup ? newData[cId.otherPhone] : existingData[cId.otherPhone];
-    userHistoryMap[cId.canWeVoicemailOther] = isInitialSignup ? newData[cId.canWeVoicemailOther] : existingData[cId.canWeVoicemailOther];
-  }
-  if (existingData[cId.prefEmail]) userHistoryMap[cId.prefEmail] = isInitialSignup ? newData[cId.prefEmail] : existingData[cId.prefEmail];
-  if (existingData[cId.additionalEmail]) userHistoryMap[cId.additionalEmail] = isInitialSignup ? newData[cId.additionalEmail] : existingData[cId.additionalEmail];
-  if (existingData[cId.address1]) userHistoryMap[cId.address1] = isInitialSignup ? newData[cId.address1] : existingData[cId.address1];
-  if (existingData[cId.address2]) userHistoryMap[cId.address2] = isInitialSignup ? newData[cId.address2] : existingData[cId.address2];
-  if (existingData[cId.city]) userHistoryMap[cId.city] = isInitialSignup ? newData[cId.city] : existingData[cId.city];
-  if (existingData[cId.state]) userHistoryMap[cId.state] = isInitialSignup ? newData[cId.state] : existingData[cId.state];
-  if (existingData[cId.zip]) userHistoryMap[cId.zip] = isInitialSignup ? newData[cId.zip] : existingData[cId.zip];
-  if (existingData[cId.firebaseAuthEmail]) userHistoryMap[cId.firebaseAuthEmail] = isInitialSignup ? newData[cId.firebaseAuthEmail] : existingData[cId.firebaseAuthEmail];
+  const keys = [
+    cId.fName,
+    cId.mName,
+    cId.lName,
+    cId.suffix,
+    cId.prefName,
+    cId.cellPhone,
+    cId.canWeVoicemailMobile,
+    cId.canWeText,
+    cId.homePhone,
+    cId.canWeVoicemailHome,
+    cId.otherPhone,
+    cId.canWeVoicemailOther,
+    cId.prefEmail,
+    cId.additionalEmail,
+    cId.address1,
+    cId.address2,
+    cId.city,
+    cId.state,
+    cId.zip,
+    cId.firebaseAuthEmail,
+  ];
 
-  if (userHistoryMap !== null) {
+  keys.forEach((key) => {
+    existingData[key] != null && (userHistoryMap[key] = existingData[key]);
+  });
+
+  if (existingData[cId.cellPhone] != null) {
+    userHistoryMap[cId.canWeVoicemailMobile] = existingData[cId.canWeVoicemailMobile];
+    userHistoryMap[cId.canWeText] = existingData[cId.canWeText];
+  }
+
+  if (existingData[cId.homePhone] != null) {
+    userHistoryMap[cId.canWeVoicemailHome] = existingData[cId.canWeVoicemailHome];
+  }
+
+  if (existingData[cId.otherPhone] != null) {
+    userHistoryMap[cId.canWeVoicemailOther] = existingData[cId.canWeVoicemailOther];
+  }
+
+  if (Object.keys(userHistoryMap).length > 0) {
     userHistoryMap[cId.userProfileUpdateTimestamp] = new Date().toISOString();
   }
 


### PR DESCRIPTION
This PR handles user profile archiving in connectApp.
It also fixes a couple of lingering bugs in issue #20 - making user profiles editable in connectApp after verification.

issue 635: https://github.com/episphere/connect/issues/635
issue 20: https://github.com/episphere/connectApp/issues/20

-update & test logic around history writing
-added `refreshUserData()` to update userData after successful write. This gets past the issue where multiple writes in the same screen caused the latest write to overwrite the previous one.

Profile archiving rules:
-create new object {} in user history for each profile update and include timestamp for the user action.
-if field was empty and user adds data, write an empty string to history.
-if field was populated and user removes data, write an empty string to user profile.
-yes/no radio buttons (phone voicemail and text permissions) are handled when the associated phone number is changed.

Additional issue found: profile form was *sometimes* loading multiple times when navigating from other parts of the app.
Solution: Took more control over the build flow and added explicit calls to display the main form divs.