### PR TITLE
[#558] Content for COVID-19 Survey description

### DIFF
--- a/js/fieldToConceptIdMapping.js
+++ b/js/fieldToConceptIdMapping.js
@@ -82,7 +82,8 @@ export default
         "D_166676176":      "ModuleSsn",
         "D_299215535":      "Biospecimen",
         "D_912367929":      "MenstrualCycle",
-        "D_826163434":      "ClinicalBiospecimen"
+        "D_826163434":      "ClinicalBiospecimen",
+        "D_793330426":      "ModuleCovid19"
     },
 
     "Module1_OLD": {
@@ -144,6 +145,15 @@ export default
         "statusFlag":       "126331570", 
         "standaloneSurvey": true,
         "version":          "628939958"
+    },
+    
+    "ModuleCovid19": {
+        "conceptId":        "D_793330426", 
+        "startTs":          "268176409", 
+        "completeTs":       "784810139",  
+        "statusFlag":       "220186468", 
+        "standaloneSurvey": true,
+        "version":          "931332817"
     },
 
     "Biospecimen": {

--- a/js/pages/myToDoList.js
+++ b/js/pages/myToDoList.js
@@ -311,7 +311,7 @@ const renderMainBody = (data, collections, tab) => {
     let modules = questionnaireModules();
     modules = setModuleAttributes(data, modules, collections);
     
-    let toDisplaySystem = [{'header':'First Survey', 'body': ['Background and Overall Health', 'Where You Live and Work', 'Medications, Reproductive Health, Exercise, and Sleep', 'Smoking, Alcohol, and Sun Exposure']}, {'body':['Covid-19','Enter SSN']}]
+    let toDisplaySystem = [{'header':'First Survey', 'body': ['Background and Overall Health', 'Where You Live and Work', 'Medications, Reproductive Health, Exercise, and Sleep', 'Smoking, Alcohol, and Sun Exposure']}, {'body':['Enter SSN']}]
     if(data['821247024'] && data['821247024'] == 875007964){
         toDisplaySystem = [{'header':'First Survey', 'body': ['Background and Overall Health', 'Where You Live and Work', 'Medications, Reproductive Health, Exercise, and Sleep', 'Smoking, Alcohol, and Sun Exposure']}]
     }
@@ -328,6 +328,10 @@ const renderMainBody = (data, collections, tab) => {
         toDisplaySystem.unshift({'body':['Menstrual Cycle']})
     }
 
+    if(modules['Covid-19'].enabled) {
+        toDisplaySystem.unshift({'body':['Covid-19']});
+    }
+    
     if(tab === 'todo'){
         let hasModlesRemaining = false;
 
@@ -653,8 +657,6 @@ const setModuleAttributes = (data, modules, collections) => {
     
     modules['Covid-19'].header = 'COVID-19'
     modules['Covid-19'].description = 'This survey asks questions about your history of COVID-19, including any vaccinations you may have received and details about times you may have gotten sick with COVID-19.';
-    modules['Covid-19'].hasIcon = false;
-    modules['Covid-19'].noButton = false;
     modules['Covid-19'].estimatedTime = 'Less than 5 minutes'
 
     modules['Biospecimen Survey'].header = 'Baseline Blood, Urine, and Mouthwash Sample Survey';
@@ -671,10 +673,12 @@ const setModuleAttributes = (data, modules, collections) => {
 
     if(data['331584571']?.['266600170']?.['840048338']) {
         modules['Biospecimen Survey'].enabled = true;
+        modules['Covid-19'].enabled = true;
     }
 
     if(collections && collections.filter(collection => collection['650516960'] === 664882224).length > 0) {
         modules['Clinical Biospecimen Survey'].enabled = true;
+        modules['Covid-19'].enabled = true;
     }
 
     if(data['289750687'] === 353358909) {

--- a/js/pages/myToDoList.js
+++ b/js/pages/myToDoList.js
@@ -311,7 +311,7 @@ const renderMainBody = (data, collections, tab) => {
     let modules = questionnaireModules();
     modules = setModuleAttributes(data, modules, collections);
     
-    let toDisplaySystem = [{'header':'First Survey', 'body': ['Background and Overall Health', 'Where You Live and Work', 'Medications, Reproductive Health, Exercise, and Sleep', 'Smoking, Alcohol, and Sun Exposure']}, {'body':['Enter SSN']}]
+    let toDisplaySystem = [{'header':'First Survey', 'body': ['Background and Overall Health', 'Where You Live and Work', 'Medications, Reproductive Health, Exercise, and Sleep', 'Smoking, Alcohol, and Sun Exposure']}, {'body':['Covid-19','Enter SSN']}]
     if(data['821247024'] && data['821247024'] == 875007964){
         toDisplaySystem = [{'header':'First Survey', 'body': ['Background and Overall Health', 'Where You Live and Work', 'Medications, Reproductive Health, Exercise, and Sleep', 'Smoking, Alcohol, and Sun Exposure']}]
     }
@@ -650,6 +650,12 @@ const setModuleAttributes = (data, modules, collections) => {
     modules['Enter SSN'].hasIcon = false;
     modules['Enter SSN'].noButton = false;
     modules['Enter SSN'].estimatedTime = 'Less than 5 minutes'
+    
+    modules['Covid-19'].header = 'COVID-19'
+    modules['Covid-19'].description = 'This survey asks questions about your history of COVID-19, including any vaccinations you may have received and details about times you may have gotten sick with COVID-19.';
+    modules['Covid-19'].hasIcon = false;
+    modules['Covid-19'].noButton = false;
+    modules['Covid-19'].estimatedTime = 'Less than 5 minutes'
 
     modules['Biospecimen Survey'].header = 'Baseline Blood, Urine, and Mouthwash Sample Survey';
     modules['Biospecimen Survey'].description = 'Questions about recent actions, like when you last ate and when you went to sleep and woke up on the day you donated samples, and your history of COVID-19. ';
@@ -701,6 +707,10 @@ const setModuleAttributes = (data, modules, collections) => {
 
     if (data[fieldMapping.ModuleSsn.statusFlag] === fieldMapping.moduleStatus.submitted) { 
         modules['Enter SSN'].completed = true;
+    };
+    
+    if (data[fieldMapping.ModuleCovid19.statusFlag] === fieldMapping.moduleStatus.submitted) { 
+        modules['Covid-19'].completed = true;
     };
 
     if (data[fieldMapping.Biospecimen.statusFlag] === fieldMapping.moduleStatus.submitted) { 

--- a/js/shared.js
+++ b/js/shared.js
@@ -877,7 +877,7 @@ export const questionnaireModules = () => {
             'Smoking, Alcohol, and Sun Exposure': {path: 'module3Stage.txt', moduleId:"Module3", enabled:false},
             'Where You Live and Work': {path: 'module4Stage.txt', moduleId:"Module4", enabled:false},
             'Enter SSN': {path: 'ssnModule.txt', moduleId:"ModuleSsn", enabled:false},
-            'Covid-19': {path: 'mockSurvey.txt', moduleId:"ModuleCovid19", enabled:true},
+            'Covid-19': {path: 'moduleCOVID19Stage.txt', moduleId:"ModuleCovid19", enabled:true},
             'Biospecimen Survey': {path: 'moduleBiospecimenStage.txt', moduleId:"Biospecimen", enabled:false},
             'Clinical Biospecimen Survey': {path: 'moduleClinicalBloodUrineStage.txt', moduleId:"ClinicalBiospecimen", enabled:false},
             'Menstrual Cycle': {path: 'moduleMenstrualStage.txt', moduleId:"MenstrualCycle", enabled:false}

--- a/js/shared.js
+++ b/js/shared.js
@@ -877,6 +877,7 @@ export const questionnaireModules = () => {
             'Smoking, Alcohol, and Sun Exposure': {path: 'module3Stage.txt', moduleId:"Module3", enabled:false},
             'Where You Live and Work': {path: 'module4Stage.txt', moduleId:"Module4", enabled:false},
             'Enter SSN': {path: 'ssnModule.txt', moduleId:"ModuleSsn", enabled:false},
+            'Covid-19': {path: 'mockSurvey.txt', moduleId:"ModuleCovid19", enabled:true},
             'Biospecimen Survey': {path: 'moduleBiospecimenStage.txt', moduleId:"Biospecimen", enabled:false},
             'Clinical Biospecimen Survey': {path: 'moduleClinicalBloodUrineStage.txt', moduleId:"ClinicalBiospecimen", enabled:false},
             'Menstrual Cycle': {path: 'moduleMenstrualStage.txt', moduleId:"MenstrualCycle", enabled:false}


### PR DESCRIPTION
This PR addresses issue https://github.com/episphere/connectApp/issues/558 -  Implement the content below as the description for the new COVID-19 Survey on the PWA dashboard in dev `This survey asks questions about your history of COVID-19, including any vaccinations you may have received and details about times you may have gotten sick with COVID-19.`

- Added `ModuleCovid19` concept ids in `fieldToConceptIdMapping.js`
- Added `questionnaireModule` for covid-19 in `shared.js`
- Added informations for module covid-19 in `myToDoList.js`
