### PR TITLE
update login not found explanation text

### DIFF
--- a/js/pages/homePage.js
+++ b/js/pages/homePage.js
@@ -500,7 +500,7 @@ export async function signInCheckRender ({ ui }) {
       <h5>Not Found</h5>
       <div class="d-flex flex-column justify-content-left ">
         <p>Your ${account.type} (${account.value}) cannot be found.</p>
-        <p> If you’re having trouble signing in or don’t remember your account information, please contact the Connect Support Center at 
+        <p>If you’re having trouble signing in or don’t remember your account information, please contact the Connect Support Center at 
           <a href="tel:+18664626621">1-866-462-6621</a> or 
           <a href="mailto:ConnectStudy@norc.org">ConnectStudy@norc.org</a> before creating a new account.
         </p>

--- a/js/pages/homePage.js
+++ b/js/pages/homePage.js
@@ -500,6 +500,10 @@ export async function signInCheckRender ({ ui }) {
       <h5>Not Found</h5>
       <div class="d-flex flex-column justify-content-left ">
         <p>Your ${account.type} (${account.value}) cannot be found.</p>
+        <p> If you’re having trouble signing in or don’t remember your account information, please contact the Connect Support Center at 
+          <a href="tel:+18664626621">1-866-462-6621</a> or 
+          <a href="mailto:ConnectStudy@norc.org">ConnectStudy@norc.org</a> before creating a new account.
+        </p>
         <p>Use another account? <a href="#" id="useAnotherAccount">Click here</a> </p>
         <p>Don't have an account? <a href="#" id="createNewAccount">Create one here</a> </p>
       <div>


### PR DESCRIPTION
Here's a quick PR addressing [issue 570](https://github.com/episphere/connectApp/issues/570)

It adds a description of who to contact when a participant can't remember login information:

“If you’re having trouble signing in or don’t remember your account information, please contact the Connect Support Center at 1-866-462-6621 or ConnectStudy@norc.org before creating a new account.”
<img width="1478" alt="Screenshot 2023-06-12 at 8 54 07 AM" src="https://github.com/episphere/connectApp/assets/93854858/de1805b5-193b-46a0-93fc-865816e538b8">
