### PR TITLE
profile version -> data team compatibility request

### DIFF
--- a/js/fieldToConceptIdMapping.js
+++ b/js/fieldToConceptIdMapping.js
@@ -42,6 +42,7 @@ export default
     "dataDestroyCategorical": 883668444,
     "requestedDataDestroyNotSigned": 111959410,
     "requestedDataDestroySigned": 704529432,
+    "noneOfTheseApply": 398561594,
     firstSignInTime: 335767902,
 
     "heardAboutStudyForm" : 142654897,

--- a/js/pages/settings.js
+++ b/js/pages/settings.js
@@ -87,7 +87,7 @@ export const renderSettingsPage = async () => {
     optVars.canWeVoicemailHome = userData[cId.canWeVoicemailHome] === cId.yes;
     optVars.canWeVoicemailOther = userData[cId.canWeVoicemailOther] === cId.yes;
     optVars.middleName = userData[cId.mName];
-    optVars.suffix = userData[cId.suffix];
+    optVars.suffix = userData[cId.suffix] && userData[cId.suffix] !== cId.noneOfTheseApply ? userData[cId.suffix] : '';
     optVars.preferredFirstName = userData[cId.prefName];
     optVars.mobilePhoneNumberComplete = userData[cId.cellPhone];
     optVars.homePhoneNumberComplete = userData[cId.homePhone];
@@ -99,16 +99,22 @@ export const renderSettingsPage = async () => {
     formVisBools.isMailingAddressFormDisplayed = false;
     formVisBools.isLoginFormDisplayed = false;
     if (userData[cId.userProfileSubmittedAutogen] === cId.yes) {
+      let headerMessage = '';
+      if (!isParticipantDataDestroyed) {
+        if (userData[cId.verification] !== cId.verified) {
+            headerMessage = "Thank you for joining the National Cancer Institute's Connect for Cancer Prevention Study. Your involvement is very important. We are currently verifying your profile, which may take up to 3 business days.";
+        }
+      } else {
+        headerMessage = `We have deleted your information based on the data destruction request we received from you. If you have any questions, please contact the <a href="#support">Connect Support Center</a>.`;
+      }
+
       template += `
             <div class="row" style="margin-top:58px">
                 <div class="col-lg-3">
                 </div>
                 <div class="col-lg-6" id="myProfileHeader">
                     <p id="pendingVerification" style="color:${!isParticipantDataDestroyed ? '#1c5d86' : 'red'}; display:none;">
-                    ${!isParticipantDataDestroyed
-                        ? "Thank you for joining the National Cancer Institute's Connect for Cancer Prevention Study. Your involvement is very important. We are currently verifying your profile, which may take up to 3 business days."
-                        : `We have deleted your information based on the data destruction request form you signed. If you have any questions, please contact the <a href="#support">Connect Support Center</a>.`
-                    }
+                    ${headerMessage}
                     <br>
                     </p>
                     <p class="consentHeadersFont" id="myProfileTextContainer" style="color:#606060; display:none;">

--- a/js/settingsHelpers.js
+++ b/js/settingsHelpers.js
@@ -689,9 +689,7 @@ const findChangedUserDataValues = (newUserData, existingUserData, type) => {
     if (newUserData[key] !== existingUserData[key]) {
       changedUserDataForProfile[key] = newUserData[key];
       if (!excludeHistoryKeys.includes(key)) {
-        if (existingUserData[key] || !keysToSkipIfNull.includes(existingUserData[key])) {
           changedUserDataForHistory[key] = existingUserData[key] ?? '';
-        }
       }
     }
   });
@@ -739,6 +737,10 @@ const findChangedUserDataValues = (newUserData, existingUserData, type) => {
       }
     }
   }
+
+  keysToSkipIfNull.forEach(key => {
+    if (changedUserDataForHistory[key] === '') changedUserDataForHistory[key] = null;
+  });
 
   return { changedUserDataForProfile, changedUserDataForHistory };
 };
@@ -817,16 +819,16 @@ const populateUserHistoryMap = (existingData, preferredEmail, newSuffix) => {
   });
 
   if (existingData[cId.cellPhone]) {
-    userHistoryMap[cId.canWeVoicemailMobile] = existingData[cId.canWeVoicemailMobile];
-    userHistoryMap[cId.canWeText] = existingData[cId.canWeText];
+    userHistoryMap[cId.canWeVoicemailMobile] = existingData[cId.canWeVoicemailMobile] ?? cId.no;
+    userHistoryMap[cId.canWeText] = existingData[cId.canWeText] ?? cId.no;
   }
 
   if (existingData[cId.homePhone]) {
-    userHistoryMap[cId.canWeVoicemailHome] = existingData[cId.canWeVoicemailHome];
+    userHistoryMap[cId.canWeVoicemailHome] = existingData[cId.canWeVoicemailHome] ?? cId.no;
   }
 
   if (existingData[cId.otherPhone]) {
-    userHistoryMap[cId.canWeVoicemailOther] = existingData[cId.canWeVoicemailOther];
+    userHistoryMap[cId.canWeVoicemailOther] = existingData[cId.canWeVoicemailOther] ?? cId.no;
   }
 
   if (newSuffix && !existingData[cId.suffix]) {


### PR DESCRIPTION
This PR is in continued support of https://github.com/episphere/connect/issues/635

It addresses BigQuery compatibility requests from the data team:

(1) disconnect previously empty phone permissions from profile history (don’t tie them to the phone number)

(2) force datatypes
	√-suffix: wrap with parseInt
	√-suffix: if populated then deleted, use new cId 398561594
	√-phone permissions: wrap with parseInt

(3) write on data deletion
	√-phone numbers empty string (unchanged)
	√-phone permissions: default to 104430631 ('no') instead of empty string

(4) write to history
	√-suffix: if previously undefined, use new cId 398561594
	√-phone permissions
	√-if existing phoneNumber value is falsy, do not write permissions to history

(5) UI: handle undefined suffix related to new cId 398561594

(6) UI: Fix verification messaging:
        √-on verified profile, don't show a message
        √-on unverified profile, show a 'wating for verification' message
        √-on data destroyed profile, show a 'data destroyed' message

