### PR TITLE
Connect app expand name search & fix multi-login type reporting

### DIFF
--- a/app.js
+++ b/app.js
@@ -262,7 +262,7 @@ const userProfile = () => {
             const userData = await getMyData();
 
             window.history.replaceState({},'Dashboard', './#dashboard');
-            if(user.email && !user.emailVerified){
+            if(user.email && !user.emailVerified && !user.email.startsWith('noreply')) {
                 const mainContent = document.getElementById('root');
                 mainContent.innerHTML = `
                     <br>

--- a/js/event.js
+++ b/js/event.js
@@ -519,10 +519,10 @@ export const addEventUPSubmit = () => {
         let formData = {};
         formData['507120821'] = 602439976;
         formData['399159511'] = document.getElementById('UPFirstName').value.trim();
-        formData['query.firstName'] = document.getElementById('UPFirstName').value.trim().toLowerCase();
+        formData['query.firstName'] = [document.getElementById('UPFirstName').value.trim().toLowerCase()];
         formData['231676651'] = document.getElementById('UPMiddleInitial').value.trim();
         formData['996038075'] = document.getElementById('UPLastName').value.trim();
-        formData['query.lastName'] = document.getElementById('UPLastName').value.trim().toLowerCase();
+        formData['query.lastName'] = [document.getElementById('UPLastName').value.trim().toLowerCase()];
         
         /*
          *TODO

--- a/js/fieldToConceptIdMapping.js
+++ b/js/fieldToConceptIdMapping.js
@@ -7,6 +7,8 @@ export default
     "birthMonth":564964481,
     "birthDay":795827569,
     "birthYear":544150384,
+    "consentFirstName": 471168198,
+    "consentLastName": 736251808,
     "consentDate":454445267,
     "suffix":506826178,
     "homePhone":438643922,

--- a/js/pages/consent.js
+++ b/js/pages/consent.js
@@ -1090,8 +1090,8 @@ const consentSubmit = async e => {
     formData['736251808'] = CSLastName.value.trim();
     formData['480305327'] = CSNameSuffix.value === '' ? undefined : parseInt(CSNameSuffix.value);
     formData['982402227'] = CSDate.split('/')[2]+CSDate.split('/')[0]+CSDate.split('/')[1];
-    formData['query.firstName'] = CSFirstName.value.trim().toLowerCase();
-    formData['query.lastName'] = CSLastName.value.trim().toLowerCase();
+    formData['query.firstName'] = [CSFirstName.value.trim().toLowerCase()];
+    formData['query.lastName'] = [CSLastName.value.trim().toLowerCase()];
     formData['919254129'] = 353358909;
     formData['454445267'] = dateTime();
     formData['262613359'] = dateTime();

--- a/js/pages/settings.js
+++ b/js/pages/settings.js
@@ -481,25 +481,31 @@ const submitNewLoginMethod = async (email, phone) => {
     const loginPhoneField = document.getElementById('loginPhoneField');
     const loginEmailDiv = document.getElementById('loginEmailDiv');
     const loginPhoneDiv = document.getElementById('loginPhoneDiv');
+    const loginEmailRow = document.getElementById('loginEmailRow');
+    const loginPhoneRow = document.getElementById('loginPhoneRow');
     
     if (optVars.loginEmail) {
-        document.getElementById('loginEmailRow').style.display = 'block';
+        loginEmailRow.style.display = 'block';
         profileEmailElement.innerHTML = optVars.loginEmail;
         profileEmailElement.style.display = 'block';
         loginEmailField && (loginEmailField.innerHTML = optVars.loginEmail);
         loginEmailDiv && (loginEmailDiv.style.display = 'block');
     } else {
+        console.log('login email else');
+        loginEmailRow && (loginEmailRow.style.display = 'none');
         loginEmailDiv && (loginEmailDiv.style.display = 'none');
         profileEmailElement.style.display = 'none';
     }
 
     if (optVars.loginPhone) {
-        document.getElementById('loginPhoneRow').style.display = 'block';
+        loginPhoneRow.style.display = 'block';
         profilePhoneElement.innerHTML = `${optVars.loginPhone}`;
         profilePhoneElement.style.display = 'block';
         loginPhoneField && (loginPhoneField.innerHTML = optVars.loginPhone);
         loginPhoneDiv && (loginPhoneDiv.style.display = 'block');        
     } else {
+        console.log('login phone else');
+        loginPhoneRow && (loginPhoneRow.style.display = 'none');
         loginPhoneDiv && (loginPhoneDiv.style.display = 'none');
         profilePhoneElement.style.display = 'none';
     }

--- a/js/pages/settings.js
+++ b/js/pages/settings.js
@@ -1387,7 +1387,7 @@ const renderTabbedForm = () => {
             ${renderEmailOrPhoneInput('email')}
             ${renderConfirmationModal('Email')}
             <br>
-            <button id="changeEmailSubmit" class="btn btn-primary save-data consentNextButton">Submit Email Update</button>
+            <button id="changeEmailSubmit" class="btn btn-primary save-data consentNextButton">Submit new login email</button>
         </div>
         
         <div id="form2" class="tabcontent">
@@ -1408,7 +1408,7 @@ const renderTabbedForm = () => {
             <br>
             ${renderConfirmationModal('Phone')}
             <p style="color:#1c5d86;">After you click, “Submit,” a pop-up box will display and ask you to enter the verification code sent to your mobile device. Please enter this code and click “OK” to verify your phone number.</p>
-            <button id="changePhoneSubmit" class="btn btn-primary save-data consentNextButton">Submit Phone Update</button>
+            <button id="changePhoneSubmit" class="btn btn-primary save-data consentNextButton">Submit new login phone number</button>
             <br>
             <div style="margin-left:10px" id="recaptcha-container"></div>
         </div> 
@@ -1418,32 +1418,36 @@ const renderTabbedForm = () => {
 const renderEmailOrPhoneInput = (type) => {  
     const phoneEmailMap = {
         email: {
-            label: 'New Email Address',
+            label: 'email',
+            heading: 'New Email Address',
+            placeholder: 'email address',
             elementId: 'Email',
         },
         phone: {
-            label: 'New Phone Number',
+            label: 'mobile phone number',
+            heading: 'New Mobile Phone Number',
+            placeholder: 'mobile phone number',
             elementId: 'Phone',
         },
     };  
-    const { label, elementId } = phoneEmailMap[type] || phoneEmailMap.email;
+    const { label, heading, placeholder, elementId } = phoneEmailMap[type] || phoneEmailMap.email;
 
     return `
         <span>Update your login ${label}:</span>
         <br>
         <br>
         <label for="new${elementId}Field" class="custom-form-label">
-            ${label} <span class="required">*</span>
+            ${heading} <span class="required">*</span>
         </label>
         <br>
-        <input type="${elementId.toLowerCase()}" id="new${elementId}Field" class="form-control required-field" placeholder="Enter New ${label}"/>
+        <input type="${elementId.toLowerCase()}" id="new${elementId}Field" class="form-control required-field" placeholder="Enter new ${placeholder}"/>
         <br>
         <br>
         <label for="new${elementId}FieldCheck" class="custom-form-label">
-            Confirm ${label} <span class="required">*</span>
+            Confirm ${heading} <span class="required">*</span>
         </label>
         <br>
-        <input type="${elementId.toLowerCase()}" id="new${elementId}FieldCheck" class="form-control required-field" placeholder="Confirm New ${label}"/>
+        <input type="${elementId.toLowerCase()}" id="new${elementId}FieldCheck" class="form-control required-field" placeholder="Confirm new ${placeholder}"/>
         <br>
     `;
 };

--- a/js/pages/settings.js
+++ b/js/pages/settings.js
@@ -469,9 +469,10 @@ const submitNewLoginMethod = async (email, phone) => {
     clearLoginFormFields();
     formVisBools.isLoginFormDisplayed = toggleElementVisibility(loginElementArray, formVisBools.isLoginFormDisplayed);
     toggleButtonText();
+    document.getElementById('changePhoneSubmit').style.display = 'block';
     document.getElementById('changeLoginGroup').style.display = 'none';
 
-    optVars.loginEmail = userData[cId.firebaseAuthEmail] ? userData[cId.firebaseAuthEmail] : '';
+    optVars.loginEmail = userData[cId.firebaseAuthEmail] && !userData[cId.firebaseAuthEmail].startsWith('noreply') ? userData[cId.firebaseAuthEmail] : '';
     optVars.loginPhone = formatFirebaseAuthPhoneNumber(userData[cId.firebaseAuthPhone]);
 
     const profileEmailElement = document.getElementById('profileEmail');
@@ -480,7 +481,7 @@ const submitNewLoginMethod = async (email, phone) => {
     const loginPhoneField = document.getElementById('loginPhoneField');
     const loginEmailDiv = document.getElementById('loginEmailDiv');
     const loginPhoneDiv = document.getElementById('loginPhoneDiv');
-
+    
     if (optVars.loginEmail) {
         document.getElementById('loginEmailRow').style.display = 'block';
         profileEmailElement.innerHTML = optVars.loginEmail;
@@ -488,6 +489,7 @@ const submitNewLoginMethod = async (email, phone) => {
         loginEmailField && (loginEmailField.innerHTML = optVars.loginEmail);
         loginEmailDiv && (loginEmailDiv.style.display = 'block');
     } else {
+        loginEmailDiv && (loginEmailDiv.style.display = 'none');
         profileEmailElement.style.display = 'none';
     }
 
@@ -498,6 +500,7 @@ const submitNewLoginMethod = async (email, phone) => {
         loginPhoneField && (loginPhoneField.innerHTML = optVars.loginPhone);
         loginPhoneDiv && (loginPhoneDiv.style.display = 'block');        
     } else {
+        loginPhoneDiv && (loginPhoneDiv.style.display = 'none');
         profilePhoneElement.style.display = 'none';
     }
 
@@ -607,7 +610,7 @@ const attachLoginEditFormButtons = async () => {
                     try {
                         const firebaseUser = firebase.auth().currentUser;
                         if (firebaseUser.email && firebaseUser.phoneNumber) {
-                            result = await unlinkFirebaseAuthProvider(type.toLowerCase(), userData);
+                            result = await unlinkFirebaseAuthProvider(type.toLowerCase(), userData, null, true);
                             const isSuccess = result === true;
                             closeModal(type);
                             updateUIAfterUnlink(isSuccess, type, isSuccess ? null : result);

--- a/js/pages/settings.js
+++ b/js/pages/settings.js
@@ -491,7 +491,6 @@ const submitNewLoginMethod = async (email, phone) => {
         loginEmailField && (loginEmailField.innerHTML = optVars.loginEmail);
         loginEmailDiv && (loginEmailDiv.style.display = 'block');
     } else {
-        console.log('login email else');
         loginEmailRow && (loginEmailRow.style.display = 'none');
         loginEmailDiv && (loginEmailDiv.style.display = 'none');
         profileEmailElement.style.display = 'none';
@@ -504,7 +503,6 @@ const submitNewLoginMethod = async (email, phone) => {
         loginPhoneField && (loginPhoneField.innerHTML = optVars.loginPhone);
         loginPhoneDiv && (loginPhoneDiv.style.display = 'block');        
     } else {
-        console.log('login phone else');
         loginPhoneRow && (loginPhoneRow.style.display = 'none');
         loginPhoneDiv && (loginPhoneDiv.style.display = 'none');
         profilePhoneElement.style.display = 'none';

--- a/js/pages/settings.js
+++ b/js/pages/settings.js
@@ -1336,7 +1336,7 @@ export const renderChangeSignInInformationGroup = () => {
         <div class="row userProfileLinePaddings" id="changeLoginGroup" style="display:none;">
             <div class="col">
                 <span class="userProfileBodyFonts">
-                    Need to update your sign-in information? Choose your preferred login method below:
+                    Need to update your sign-in information? Add or update your information below:
                 </span>
                 <br>
                 <br>
@@ -1366,8 +1366,8 @@ export const renderChangeSignInInformationGroup = () => {
 const renderTabbedForm = () => {
     return `
         <div class="tab">
-            <button class="tablinks">Use email</button>
-            <button class="tablinks">Use mobile phone</button>
+            <button class="tablinks">Update email</button>
+            <button class="tablinks">Update mobile phone</button>
         </div>
         <br>
         <div id="form1" class="tabcontent">

--- a/js/pages/settings.js
+++ b/js/pages/settings.js
@@ -1451,4 +1451,4 @@ const renderConfirmationModal = (removalType) => {
         </div>
     </div>
     `;
-};  
+};

--- a/js/settingsHelpers.js
+++ b/js/settingsHelpers.js
@@ -405,8 +405,8 @@ export const changeContactInformation = async (mobilePhoneNumberComplete, homePh
   return isSuccess;
 };
 
-const firstNameTypes = [cId.fName, cId.prefName, cId.consentFirstName];
-const lastNameTypes = [cId.lName, cId.consentLastName];
+const firstNameTypes = [cId.consentFirstName, cId.fName, cId.prefName];
+const lastNameTypes = [cId.consentLastName, cId.lName];
 
 /**
  * Handle the query.frstName and query.lastName fields in the participant profile.

--- a/js/settingsHelpers.js
+++ b/js/settingsHelpers.js
@@ -429,9 +429,7 @@ const handleNameField = (nameTypes, fieldName, changedUserDataForProfile, userDa
       }
   });
 
-  const uniqueNameArray = Array.from(new Set(queryNameArray));
-
-  changedUserDataForProfile[`query.${fieldName}`] = uniqueNameArray;
+  changedUserDataForProfile[`query.${fieldName}`] = Array.from(new Set(queryNameArray));
 
   return changedUserDataForProfile;
 };
@@ -635,6 +633,9 @@ const updateFirebaseAuthPhone = async (phone, userData) => {
  * Important: FirebaseAuth phone number can be unlinked. FirebaseAuth email cannot be unlinked.
  * Workaround: If the user wants to unlink their email, we write a 'noreply' email to the user's auth profile and firestore profile, which effectively disables the prior email login.
  * @param {String} providerType - 'email' or 'phone' 
+ * @param {Object} userData - the user's current userData object
+ * @param {String} newPhone - the new phone number (if applicable)
+ * @param {boolean} isPhoneRemoval - true if the phone number is being removed, false otherwise
  * @returns {boolean} - true if the unlink was successful, false otherwise
  */
 export const unlinkFirebaseAuthProvider = async (providerType, userData, newPhone, isPhoneRemoval) => {
@@ -711,10 +712,6 @@ export const updateToNoReplyEmail = async (uid, noReplyEmail) => {
       throw error;
     }
 };
-
-
-
-
 
 const handleUpdatePhoneEmailErrorInUI = (functionName, error) => {
   document.getElementById('loginUpdateFail').style.display = 'block';

--- a/js/settingsHelpers.js
+++ b/js/settingsHelpers.js
@@ -700,10 +700,6 @@ export const updateToNoReplyEmail = async (uid, noReplyEmail) => {
     document.getElementById('loginUpdateFail').style.display = 'none';
     document.getElementById('loginUpdateSuccess').style.display = 'none';
     
-    const valuesForFirebaseAuth = {};
-    valuesForFirebaseAuth['email'] = noReplyEmail;
-    valuesForFirebaseAuth['uid'] = uid;
-    
     try {
       await updateFirebaseAuthEmail(noReplyEmail);
       return true;


### PR DESCRIPTION
This PR is in support of
Connect issue 564 https://github.com/episphere/connect/issues/654
and (separate item, specifying since the number is the same)
ConnectApp PR 564 https://github.com/episphere/connectApp/pull/564
and
Issue: https://github.com/episphere/connect/issues/666

Re: expand name search
•Write updates to `query.firstName` and `query.lastName` fields as arrays.
query.firstName field includes: consent first name (471168198), first name (399159511), and preferred name (153211406).
query.lastName field includes: consent last name (736251808) and last name(996038075).
•Write query.firstName and query.lastName as array on signup (compatible with new data structure and connectFaas search function).

Re: Multi-logins
•Fix handling of `phone`, `password`, and `passwordAndPhone` sign-in mechanism reporting (995036844). The issue was: ‘noreply’ emails were not factored into the reporting functionality, so removed emails were causing incorrect reporting of sign-in mechanism.

Re: UI updates
•Fixed: After removing sign-in email address and then updating phone number, sign-in email heading is visible.
•Fixed: After removing sign-in phone number and then updating email address, sign-in phone number heading is visible.
•Fixed: Verify email prompt was showing on landing page when participant had a ‘noreply’ email.
•Updated text per https://github.com/episphere/connect/issues/666#issuecomment-1632750506