### PR TITLE
Adding Clinical Survey Data to Quest Pipeline

### DIFF
--- a/js/pages/questionnaire.js
+++ b/js/pages/questionnaire.js
@@ -22,7 +22,7 @@ export const questionnaire = async (moduleId) => {
     if(hasUserData(responseData)) {
         data = responseData.data;
 
-        let responseModules = await getMySurveys([...new Set([fieldMapping.Module1.conceptId, fieldMapping.Module1_OLD.conceptId, fieldMapping.Biospecimen.conceptId, fieldMapping[moduleId].conceptId])]);
+        let responseModules = await getMySurveys([...new Set([fieldMapping.Module1.conceptId, fieldMapping.Module1_OLD.conceptId, fieldMapping.Biospecimen.conceptId, fieldMapping.ClinicalBiospecimen.conceptId, fieldMapping[moduleId].conceptId])]);
         if(responseModules.code === 200) {
             modules = responseModules.data;
 
@@ -341,6 +341,7 @@ const setInputData = (data, modules) => {
     let module1_v1 = modules[fieldMapping.Module1.conceptId];
     let module1_v2 = modules[fieldMapping.Module1_OLD.conceptId];
     let moduleBiospecimen = modules[fieldMapping.Biospecimen.conceptId];
+    let moduleClinical = modules[fieldMapping.ClinicalBiospecimen.conceptId];
 
     if (module1_v1) {
         if (module1_v1["D_407056417"]) inputData["D_407056417"] = module1_v1["D_407056417"];
@@ -369,6 +370,10 @@ const setInputData = (data, modules) => {
 
     if (moduleBiospecimen) {
         if (moduleBiospecimen["D_644459734"]) inputData["D_644459734"] = moduleBiospecimen["D_644459734"];
+    }
+
+    if (moduleClinical) {
+        if (moduleClinical["D_644459734"]) inputData["D_644459734"] = moduleClinical["D_644459734"];
     }
     
     let birthMonth =  data[fieldMapping.birthMonth];


### PR DESCRIPTION
This PR addresses the following Issues:
* https://github.com/episphere/connect/issues/672
-----
Background Details
* Start date of current menstrual cycle wasn't being passed in from clinical biospecimen survey results
-----
Technical Changes
* Added Clinical Biospecimen Survey to array of surveys we try to grab data from before starting a survey
* If Clinical Biospecimen Survey data exists AND CID `644459734` (Menstrual Start Date) is present, add it to Quest Input Data