### PR TITLE
Quest Rendering Bug Fix

### DIFF
--- a/js/pages/questionnaire.js
+++ b/js/pages/questionnaire.js
@@ -185,7 +185,10 @@ async function startModule(data, modules, moduleId, questDiv) {
             attributes:true,
             });
     })
-    .then(hideAnimation());
+    .then(() => {
+        document.getElementById(questDiv).style.visibility = 'visible';
+        hideAnimation();
+    });
 }
 
 function soccerFunction(){
@@ -417,6 +420,8 @@ const displayQuest = (id) => {
         </div>
     
     `;
+
+    document.getElementById(id).style.visibility = 'hidden';
 }
 
 const displayError = () => {


### PR DESCRIPTION
This PR addresses the following Issues:
* https://github.com/episphere/connect/issues/702
-----
Background Details
* PWA was allowing buttons to be clicked when a module was started prior to Quest fully rendering the module. This caused the page to unexpected crash and reload while adding a `?` to the page URL, causing our code to think we were passing in parameters.
-----
Technical Changes
* Added code to modify visibility parameter of Quest div
* Changed syntax of passing a function to `then()`