### PR TITLE
Menstrual Cycle Survey - 45 day expiration

### DIFF
--- a/js/fieldToConceptIdMapping.js
+++ b/js/fieldToConceptIdMapping.js
@@ -48,6 +48,7 @@ export default
     "noneOfTheseApply": 398561594,
     firstSignInTime: 335767902,
     pinNumber: 379080287,
+    menstrualSurveyEligible: 289750687,
 
     "heardAboutStudyForm" : 142654897,
 

--- a/js/pages/myToDoList.js
+++ b/js/pages/myToDoList.js
@@ -728,8 +728,25 @@ const setModuleAttributes = (data, modules, collections) => {
         modules['Covid-19'].enabled = true;
     }
 
-    if(data['289750687'] === 353358909) {
+    if(data[fieldMapping.menstrualSurveyEligible] === 353358909) {
         modules['Menstrual Cycle'].enabled = true;
+
+        if(data[fieldMapping.MenstrualCycle.statusFlag] != fieldMapping.moduleStatus.submitted) {
+
+            const currentDate = Date.now();
+            const milllisecondsToDays = 1000 * 60 * 60 * 24;
+
+            if(data[fieldMapping.Biospecimen.statusFlag] === fieldMapping.moduleStatus.submitted) {
+                if((currentDate - new Date(data[fieldMapping.Biospecimen.completeTs]).getTime()) / milllisecondsToDays > 45) {
+                    modules['Menstrual Cycle'].enabled = false;
+                }
+            }
+            else if(data[fieldMapping.ClinicalBiospecimen.statusFlag] === fieldMapping.moduleStatus.submitted) {
+                if((currentDate - new Date(data[fieldMapping.ClinicalBiospecimen.completeTs]).getTime()) / milllisecondsToDays > 45) {
+                    modules['Menstrual Cycle'].enabled = false;
+                }
+            }
+        }
     }
     
     if (data[fieldMapping.Module1.statusFlag] === fieldMapping.moduleStatus.submitted) { 

--- a/js/pages/myToDoList.js
+++ b/js/pages/myToDoList.js
@@ -733,16 +733,16 @@ const setModuleAttributes = (data, modules, collections) => {
 
         if(data[fieldMapping.MenstrualCycle.statusFlag] != fieldMapping.moduleStatus.submitted) {
 
-            const currentDate = Date.now();
-            const milllisecondsToDays = 1000 * 60 * 60 * 24;
+            const cutoffDate = new Date();
+            cutoffDate.setDate(cutoffDate.getDate() - 45);
 
             if(data[fieldMapping.Biospecimen.statusFlag] === fieldMapping.moduleStatus.submitted) {
-                if((currentDate - new Date(data[fieldMapping.Biospecimen.completeTs]).getTime()) / milllisecondsToDays > 45) {
+                if(data[fieldMapping.Biospecimen.completeTs] < cutoffDate.toISOString()) {
                     modules['Menstrual Cycle'].enabled = false;
                 }
             }
             else if(data[fieldMapping.ClinicalBiospecimen.statusFlag] === fieldMapping.moduleStatus.submitted) {
-                if((currentDate - new Date(data[fieldMapping.ClinicalBiospecimen.completeTs]).getTime()) / milllisecondsToDays > 45) {
+                if(data[fieldMapping.ClinicalBiospecimen.completeTs] < cutoffDate.toISOString()) {
                     modules['Menstrual Cycle'].enabled = false;
                 }
             }


### PR DESCRIPTION
This PR addresses the following Issues:
* https://github.com/episphere/connect/issues/717
-----
Background Details
* The Menstrual Cycle Survey shouldn't be showing up on the list of available surveys for a participant if they completed their Biospecimen Survey more than 45 days ago
-----
Technical Changes
* Added constant in `fieldToConceptIdMapping.js`
* Added add logic for determining if Menstrual Cycle Survey should be displayed

NOTE: The survey will always be displayed if they have submitted the survey