### PR TITLE
GetParameters() Bug Fix

### DIFF
--- a/js/shared.js
+++ b/js/shared.js
@@ -325,8 +325,10 @@ export const getParameters = (URL) => {
         const array = query.split('&');
         let obj = {};
         array.forEach(value => {
-            if(value.split('=')[1].trim() === "") return;
-            obj[value.split('=')[0]] = value.split('=')[1];
+            let split = value.split('=');
+
+            if(!value || split[1].trim() === "") return;
+            obj[split[0]] = split[1];
         });
         return obj;
     }

--- a/js/shared.js
+++ b/js/shared.js
@@ -327,7 +327,7 @@ export const getParameters = (URL) => {
         array.forEach(value => {
             let split = value.split('=');
 
-            if(!value || split[1].trim() === "") return;
+            if(!value || split[1] === undefined|| split[1].trim() === "") return;
             obj[split[0]] = split[1];
         });
         return obj;


### PR DESCRIPTION
This PR addresses the following Issues:
* https://github.com/episphere/connect/issues/702
-----
Background Details
* If a question mark is added to the end of our URL the code thinks we have parameters and tries to read them appropriately, but the code throws an error if no parameters are passed.
-----
Technical Changes
* set variable `split` to avoid multiple calls to split() function
* checking if `value` is truthy before trying to act on it
