### PR TITLE
Null Property 'click' Bug Fix

### DIFF
--- a/js/components/navbar.js
+++ b/js/components/navbar.js
@@ -2,6 +2,7 @@ import { urls , isParticipantDataDestroyed } from "../shared.js";
 
 export const userNavBar = (data) => {
     const disabledClass = isParticipantDataDestroyed(data.data) ? 'disabled': '';
+    const hiddenClass = data.code === 200 && data.data['699625233'] === 353358909 && data.data['919254129'] === 353358909 ? '': 'hidden';
 
     let template = `
         
@@ -33,22 +34,11 @@ export const userNavBar = (data) => {
                 <a class="nav-link ${disabledClass}" href="#payment" id="connectPayment"> My Payment</a>
             </li>
         </div>
-
-    `;
-
-    data.code === 200 && data.data['699625233'] === 353358909 && data.data['919254129'] === 353358909 ? 
-
-        template += `
-        
         <div class="navbar-nav transparent-border">
             <li class="nav-item">
-                <a class="nav-link ${disabledClass}" href="#samples" id="connectSamples"> My Samples</a>
+                <a class="nav-link ${disabledClass}" ${hiddenClass} href="#samples" id="connectSamples"> My Samples</a>
             </li>
         </div>
-
-    `: ``;
-        
-    template += `
         <div class="navbar-nav transparent-border">
             <li class="nav-item">
                 <a class="nav-link ${disabledClass}" href="#support" id="connectSupport"> Support</a>

--- a/js/components/navbar.js
+++ b/js/components/navbar.js
@@ -1,8 +1,8 @@
 import { urls , isParticipantDataDestroyed } from "../shared.js";
 
-export const userNavBar = (data) => {
-    const disabledClass = isParticipantDataDestroyed(data.data) ? 'disabled': '';
-    const hiddenClass = data.code === 200 && data.data['699625233'] === 353358909 && data.data['919254129'] === 353358909 ? '': 'hidden';
+export const userNavBar = (response) => {
+    const disabledClass = isParticipantDataDestroyed(response.data) ? 'disabled': '';
+    const hiddenClass = response.code === 200 && response.data['699625233'] === 353358909 && response.data['919254129'] === 353358909 ? '': 'hidden';
 
     let template = `
         


### PR DESCRIPTION
This PR addresses the following Issues:
* https://github.com/episphere/connect/issues/700
-----
Background Details
* Error is caught if the `My Samples` page is put in the page URL prior to participant "having access" to the page
* The error is caught, but the page is rendered regardless, so logic is reflecting the idea that we should just basically mute the bug
-----
Technical Changes
* changed logic to have div id `connectSamples` always render
* added dynamic attribute to add `hidden` tag if needed
