### PR TITLE
[ON HOLD] location.reload() move

### DIFF
--- a/js/shared.js
+++ b/js/shared.js
@@ -118,6 +118,8 @@ const completeSurvey = async (data, moduleId) => {
     if(data["COMPLETED_TS"]) formData[fieldMapping[moduleName].completeTs] = data["COMPLETED_TS"];
 
     await storeResponse(formData);
+
+    location.reload();
 }
 
 export const storeResponse = async (formData) => {


### PR DESCRIPTION
This PR addresses the following Issues:
* N/A
-----
Background Details
* Quest will be removing functionality to reload the page when we submit a questionnaire so we need to handle it on the PWA side
-----
Technical Changes
* added `location.reload()` call at the end of `completeSurvey()` function
