### PR TITLE
Enabling Dynamic Quest Versions

### DIFF
--- a/js/pages/questionnaire.js
+++ b/js/pages/questionnaire.js
@@ -12,11 +12,10 @@ const importQuest = async () => {
     const versionsUrl = 'https://raw.githubusercontent.com/episphere/questionnaire/main/questVersions.json';
     let questUrl;
 
-    await fetch(versionsUrl)
-        .then(async (response) => {
-            let questObject = await response.json();
-            questUrl = questObject[location.host];
-        });
+    await fetch(versionsUrl).then(async (response) => {
+        let questObject = await response.json();
+        questUrl = questObject[location.host];
+    });
 
     await import(questUrl).then(({ transform }) => {
         quest = transform;

--- a/js/pages/questionnaire.js
+++ b/js/pages/questionnaire.js
@@ -4,20 +4,15 @@ import { SOCcer as SOCcerProd } from "./../../prod/config.js";
 import { SOCcer as SOCcerStage } from "./../../stage/config.js";
 import { SOCcer as SOCcerDev } from "./../../dev/config.js";
 import { Octokit } from "https://cdn.skypack.dev/pin/octokit@v2.0.14-WDHE0c1GgF96ore7BeW1/mode=imports/optimized/octokit.js";
+import questConfig from "https://episphere.github.io/questionnaire/questVersions.js";
 
 let quest;
 
 const importQuest = async () => {
 
-    const versionsUrl = 'https://raw.githubusercontent.com/episphere/questionnaire/main/questVersions.json';
-    let questUrl;
+    let url = questConfig[location.host];
 
-    await fetch(versionsUrl).then(async (response) => {
-        let questObject = await response.json();
-        questUrl = questObject[location.host];
-    });
-
-    await import(questUrl).then(({ transform }) => {
+    await import(url).then(({ transform }) => {
         quest = transform;
     });
 }

--- a/js/pages/questionnaire.js
+++ b/js/pages/questionnaire.js
@@ -4,8 +4,24 @@ import { SOCcer as SOCcerProd } from "./../../prod/config.js";
 import { SOCcer as SOCcerStage } from "./../../stage/config.js";
 import { SOCcer as SOCcerDev } from "./../../dev/config.js";
 import { Octokit } from "https://cdn.skypack.dev/pin/octokit@v2.0.14-WDHE0c1GgF96ore7BeW1/mode=imports/optimized/octokit.js";
-import { transform } from "https://cdn.jsdelivr.net/gh/episphere/quest@v1.0.15/replace2.js"
-import { rbAndCbClick } from "https://cdn.jsdelivr.net/gh/episphere/quest@v1.0.15/questionnaire.js"
+
+let quest;
+
+const importQuest = async () => {
+
+    const versionsUrl = 'https://raw.githubusercontent.com/episphere/questionnaire/main/questVersions.json';
+    let questUrl;
+
+    await fetch(versionsUrl)
+        .then(async (response) => {
+            let questObject = await response.json();
+            questUrl = questObject[location.host];
+        });
+
+    await import(questUrl).then(({ transform }) => {
+        quest = transform;
+    });
+}
 
 export const questionnaire = async (moduleId) => {
  
@@ -33,6 +49,8 @@ export const questionnaire = async (moduleId) => {
 
 async function startModule(data, modules, moduleId, questDiv) {
 
+    await importQuest();
+    
     let inputData = setInputData(data, modules); 
     let moduleConfig = questionnaireModules();
 
@@ -123,7 +141,7 @@ async function startModule(data, modules, moduleId, questDiv) {
 
     window.scrollTo(0, 0);
 
-    transform.render(questParameters, questDiv, inputData).then(() => {
+    quest.render(questParameters, questDiv, inputData).then(() => {
         
         //Grid fix first
         let grids = document.getElementsByClassName('d-lg-block');
@@ -298,7 +316,7 @@ function buildHTML(soccerResults, question, responseElement) {
       resp.id = `${question.id}_${indx}`;
       resp.value = soc.code;
       resp.name = "SOCcerResults";
-      resp.onclick = rbAndCbClick;
+      resp.onclick = quest.rbAndCbClick;
       let label = document.createElement("label");
       label.setAttribute("for", `${question.id}_${indx}`);
       label.innerText = soc.label;
@@ -309,7 +327,7 @@ function buildHTML(soccerResults, question, responseElement) {
     resp.id = `${question.id}_NOTA`;
     resp.value = "NONE_OF_THE_ABOVE";
     resp.name = "SOCcerResults";
-    resp.onclick = rbAndCbClick;
+    resp.onclick = quest.rbAndCbClick;
     let label = document.createElement("label");
     label.setAttribute("for", `${question.id}_NOTA`);
     label.innerText = "NONE OF THE ABOVE";


### PR DESCRIPTION
This PR is a second pass at the following PR:
* https://github.com/episphere/connectApp/pull/673

This PR addresses the following Issue:
* https://github.com/episphere/connect/issues/837
-----
Background Details
* If a new Release was created in the Quest repo, changes were automatically seen across all branches of the PWA. We want to import Quest functionality from different sources depending on the URL being used in the PWA
-----
Technical Changes
* Removed top-level imports of needed Quest functions
* Created function importQuest that imports Quest library from a URL based on `location.host`
* Added references to global variable `quest`


NOTE: A new file was created to manage the logic of this PR (https://github.com/episphere/questionnaire/blob/main/questVersions.js)