### PR TITLE
Adjust mouthwash survey condition

### DIFF
--- a/js/fieldToConceptIdMapping.js
+++ b/js/fieldToConceptIdMapping.js
@@ -214,6 +214,6 @@ export default
         addressPrinted: 849527480,
         assigned: 241974920,
         shipped: 277438316,
-        recieved: 375535639
+        received: 375535639
     }
 };

--- a/js/pages/myToDoList.js
+++ b/js/pages/myToDoList.js
@@ -778,7 +778,8 @@ const setModuleAttributes = (data, modules, collections) => {
     const mouthwashData = data[fieldMapping.collectionDetails]?.[fieldMapping.baseline]?.[fieldMapping.bioKitMouthwash];
     if (
       mouthwashData?.[fieldMapping.kitType] === fieldMapping.kitTypeValues.mouthwash &&
-      mouthwashData?.[fieldMapping.kitStatus] === fieldMapping.kitStatusValues.shipped
+      (mouthwashData?.[fieldMapping.kitStatus] === fieldMapping.kitStatusValues.shipped ||
+        mouthwashData?.[fieldMapping.kitStatus] === fieldMapping.kitStatusValues.received)
     ) {
       modules.Mouthwash.enabled = true;
     }


### PR DESCRIPTION
This PR puts back 'received' as a condition of home mouthwash survey. It reverts PR [#675](https://github.com/episphere/connectApp/pull/675) based on further discussion today, to address issue [#737](https://github.com/episphere/connect/issues/737).