### PR TITLE
Revert "Enabling Dynamic Quest Versions"

### DIFF
--- a/js/pages/questionnaire.js
+++ b/js/pages/questionnaire.js
@@ -4,18 +4,8 @@ import { SOCcer as SOCcerProd } from "./../../prod/config.js";
 import { SOCcer as SOCcerStage } from "./../../stage/config.js";
 import { SOCcer as SOCcerDev } from "./../../dev/config.js";
 import { Octokit } from "https://cdn.skypack.dev/pin/octokit@v2.0.14-WDHE0c1GgF96ore7BeW1/mode=imports/optimized/octokit.js";
-import questConfig from "https://episphere.github.io/questionnaire/questVersions.js";
-
-let quest;
-
-const importQuest = async () => {
-
-    let url = questConfig[location.host];
-
-    await import(url).then(({ transform }) => {
-        quest = transform;
-    });
-}
+import { transform } from "https://cdn.jsdelivr.net/gh/episphere/quest@v1.0.15/replace2.js"
+import { rbAndCbClick } from "https://cdn.jsdelivr.net/gh/episphere/quest@v1.0.15/questionnaire.js"
 
 export const questionnaire = async (moduleId) => {
  
@@ -43,8 +33,6 @@ export const questionnaire = async (moduleId) => {
 
 async function startModule(data, modules, moduleId, questDiv) {
 
-    await importQuest();
-    
     let inputData = setInputData(data, modules); 
     let moduleConfig = questionnaireModules();
 
@@ -135,7 +123,7 @@ async function startModule(data, modules, moduleId, questDiv) {
 
     window.scrollTo(0, 0);
 
-    quest.render(questParameters, questDiv, inputData).then(() => {
+    transform.render(questParameters, questDiv, inputData).then(() => {
         
         //Grid fix first
         let grids = document.getElementsByClassName('d-lg-block');
@@ -310,7 +298,7 @@ function buildHTML(soccerResults, question, responseElement) {
       resp.id = `${question.id}_${indx}`;
       resp.value = soc.code;
       resp.name = "SOCcerResults";
-      resp.onclick = quest.rbAndCbClick;
+      resp.onclick = rbAndCbClick;
       let label = document.createElement("label");
       label.setAttribute("for", `${question.id}_${indx}`);
       label.innerText = soc.label;
@@ -321,7 +309,7 @@ function buildHTML(soccerResults, question, responseElement) {
     resp.id = `${question.id}_NOTA`;
     resp.value = "NONE_OF_THE_ABOVE";
     resp.name = "SOCcerResults";
-    resp.onclick = quest.rbAndCbClick;
+    resp.onclick = rbAndCbClick;
     let label = document.createElement("label");
     label.setAttribute("for", `${question.id}_NOTA`);
     label.innerText = "NONE OF THE ABOVE";


### PR DESCRIPTION
This update relied on a newer version of Quest that was going to go live at the same time. During testing of that new version, errors were found that regressed grid functionality and the decision was made to not go live. If that version doesn't go live, this code will break production.

Issue: https://github.com/episphere/connect/issues/837