### PR TITLE
PR 695 - Bug Fix

### DIFF
--- a/js/pages/questionnaire.js
+++ b/js/pages/questionnaire.js
@@ -217,10 +217,10 @@ function externalListeners(){
 
     let module1 = modules[fieldMapping.Module1.conceptId];
 
-    let title3 = module1['D_627122657'] ?? '';
-    let task3 = module1['D_796828094'] ?? '';
-    let title7 = module1['D_118061122'] ?? '';
-    let task7 = module1['D_518387017'] ?? '';
+    let title3 = module1?.['D_627122657'] ?? '';
+    let task3 = module1?.['D_796828094'] ?? '';
+    let title7 = module1?.['D_118061122'] ?? '';
+    let task7 = module1?.['D_518387017'] ?? '';
     
     if (work3){
         work3.addEventListener("submit", (e) => {


### PR DESCRIPTION
This PR addresses a bug from the following Pull Request:
* https://github.com/episphere/connectApp/pull/695
-----
## Background Details
* Event Listeners are created when modules are booted up and null checks need to be put in place for when someone starts Module 1 for the first time.
-----
## Technical Changes
* Added null checks to four variable declarations in `questionnaire.js`