### PR TITLE
PROMIS Survey Updates (PWA)

### DIFF
--- a/js/fieldToConceptIdMapping.js
+++ b/js/fieldToConceptIdMapping.js
@@ -75,7 +75,7 @@ export default
     },
 
     moduleStatus: {
-        notYetEligible: 789789789, // This is a placeholder value
+        notYetEligible: 789467219,
         notStarted:     972455046,
         started:        615768760,
         submitted:      231311385 

--- a/js/fieldToConceptIdMapping.js
+++ b/js/fieldToConceptIdMapping.js
@@ -75,6 +75,7 @@ export default
     },
 
     moduleStatus: {
+        notYetEligible: 789789789, // This is a placeholder value
         notStarted:     972455046,
         started:        615768760,
         submitted:      231311385 
@@ -92,7 +93,8 @@ export default
         "D_912367929":      "MenstrualCycle",
         "D_826163434":      "ClinicalBiospecimen",
         "D_793330426":      "ModuleCovid19",
-        "D_390351864":      "Mouthwash"
+        "D_390351864":      "Mouthwash",
+        "D_601305072":      "PROMIS"
     },
 
     "Module1_OLD": {
@@ -199,6 +201,15 @@ export default
         "statusFlag":       "547363263", 
         "standaloneSurvey": true,
         "version":          "850585325"
+    },
+
+    "PROMIS": {
+        "conceptId":        "D_601305072",
+        "startTs":          "870643066", 
+        "completeTs":       "843688458",  
+        "statusFlag":       "320303124", 
+        "standaloneSurvey": true,
+        "version":          "490327747"
     },
 
     collectionDetails: 173836415,

--- a/js/pages/myToDoList.js
+++ b/js/pages/myToDoList.js
@@ -5,7 +5,6 @@ import { consentTemplate } from "./consent.js";
 import { addEventHeardAboutStudy, addEventRequestPINForm, addEventHealthCareProviderSubmit, addEventPinAutoUpperCase, addEventHealthProviderModalSubmit, addEventToggleSubmit } from "../event.js";
 import { heardAboutStudy, requestPINTemplate, healthCareProvider } from "./healthCareProvider.js";
 import fieldMapping from '../fieldToConceptIdMapping.js';
-import { socialSecurityTemplate } from "./ssn.js";
 
 export const myToDoList = async (data, fromUserProfile, collections) => {
     const mainContent = document.getElementById('root');
@@ -361,11 +360,15 @@ const renderMainBody = (data, collections, tab) => {
     }
 
     if(modules['Menstrual Cycle'].enabled) {
-        toDisplaySystem.unshift({'body':['Menstrual Cycle']})
+        toDisplaySystem.unshift({'body':['Menstrual Cycle']});
     }
     
     if(modules['Mouthwash'].enabled) {
-        toDisplaySystem.unshift({'body':['Mouthwash']})
+        toDisplaySystem.unshift({'body':['Mouthwash']});
+    }
+
+    if(modules['PROMIS'].enabled) {
+        toDisplaySystem.unshift({'body':['PROMIS']});
     }
     
     if(tab === 'todo'){
@@ -695,6 +698,10 @@ const setModuleAttributes = (data, modules, collections) => {
     modules['Mouthwash'].description = 'Questions about your oral health and hygiene practices.';
     modules['Mouthwash'].estimatedTime = '5 minutes';
 
+    modules['PROMIS'].header = 'Quality of Life Survey';
+    modules['PROMIS'].description = 'Questions about your physical, social, and mental health.';
+    modules['PROMIS'].estimatedTime = '10 to 15 minutes';
+
     if(data['331584571']?.['266600170']?.['840048338']) {
         modules['Biospecimen Survey'].enabled = true;
         modules['Covid-19'].enabled = true;
@@ -724,6 +731,10 @@ const setModuleAttributes = (data, modules, collections) => {
                 }
             }
         }
+    }
+
+    if (data[fieldMapping.PROMIS.statusFlag] !== fieldMapping.moduleStatus.notYetEligible) {
+        modules['PROMIS'].enabled = true;
     }
     
     if (data[fieldMapping.Module1.statusFlag] === fieldMapping.moduleStatus.submitted) { 
@@ -781,6 +792,10 @@ const setModuleAttributes = (data, modules, collections) => {
 
     if (data[fieldMapping.Mouthwash.statusFlag] === fieldMapping.moduleStatus.submitted) { 
         modules['Mouthwash'].completed = true;
+    }
+
+    if (data[fieldMapping.PROMIS.statusFlag] === fieldMapping.moduleStatus.submitted) { 
+        modules['PROMIS'].completed = true;
     }
 
     return modules;

--- a/js/shared.js
+++ b/js/shared.js
@@ -898,7 +898,8 @@ export const questionnaireModules = () => {
             'Biospecimen Survey': {path: 'prod/moduleBiospecimen.txt', moduleId:"Biospecimen", enabled:false},
             'Clinical Biospecimen Survey': {path: 'prod/moduleClinicalBloodUrine.txt', moduleId:"ClinicalBiospecimen", enabled:false},
             'Menstrual Cycle': {path: 'prod/moduleMenstrual.txt', moduleId:"MenstrualCycle", enabled:false},
-            'Mouthwash': {path: 'prod/moduleMouthwash.txt', moduleId:"Mouthwash", enabled:false}
+            'Mouthwash': {path: 'prod/moduleMouthwash.txt', moduleId:"Mouthwash", enabled:false},
+            'PROMIS': {path: 'prod/modulePROMIS.txt', moduleId:"PROMIS", enabled:false}
         }
     }
 
@@ -912,7 +913,8 @@ export const questionnaireModules = () => {
         'Biospecimen Survey': {path: 'moduleBiospecimenStage.txt', moduleId:"Biospecimen", enabled:false},
         'Clinical Biospecimen Survey': {path: 'moduleClinicalBloodUrineStage.txt', moduleId:"ClinicalBiospecimen", enabled:false},
         'Menstrual Cycle': {path: 'moduleMenstrualStage.txt', moduleId:"MenstrualCycle", enabled:false},
-        'Mouthwash': {path: 'moduleMouthwash.txt', moduleId:"Mouthwash", enabled:false}
+        'Mouthwash': {path: 'moduleMouthwash.txt', moduleId:"Mouthwash", enabled:false},
+        'PROMIS': {path: 'modulePROMIS.txt', moduleId:"PROMIS", enabled:false}
     };
 }
 
@@ -1104,7 +1106,7 @@ const resetMenstrualCycleSurvey = async () => {
     await storeResponse(formData);
 }
 
-const removeMenstrualCycleData = (formData) => {
+const removeMenstrualCycleData = () => {
 
     localforage.removeItem("D_912367929");
     localforage.removeItem("D_912367929.treeJSON");
@@ -1121,7 +1123,7 @@ const removeMenstrualCycleData = (formData) => {
 const clientFilterData = async (formData) => {
 
     if(formData["D_912367929"]?.["D_951357171"] == 104430631) {
-        formData = removeMenstrualCycleData(formData);
+        formData = removeMenstrualCycleData();
 
         await resetMenstrualCycleSurvey();
     }


### PR DESCRIPTION
This PR addresses the following Issue:
* https://github.com/episphere/connect/issues/877
-----
## Background Details
* New PROMIS QOL Survey is being added to the study and logic needs to be put in to display the survey at the right time on the To-Do List, render the appropriate Quest markdown, and send off survey responses to the API
-----
## Technical Changes
* Added PROMIS survey Concept IDs and new module status Concept ID to `fieldToConceptIdMapping.js`
* Added PROMIS survey information in `myToDoList.js`
* Added logic to push PROMIS survey to the Display System in `myToDoList.js`
* Added logic to mark PROMIS survey as enabled and completed in `myToDoList.js`
* Added PROMIS dev / stage and prod configurations to `questionnaireModules()` in `shared.js`
* Unrelated eslint clean-up to `resetMenstrualCycleSurvey()` in `shared.js`
 