### PR TITLE
quest container improvements

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1042,7 +1042,7 @@ consentNextButton:hover{
         text-align:center;
         height:150px;
     }
-    .container{
+    .container {
         padding-top: 1rem;
     }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -8,7 +8,7 @@ a{
 
 .container {
     min-height: calc(100vh - 128px);
-    padding-top: 5rem;
+    padding-top: 3rem;
 }
 
 #root {
@@ -1041,6 +1041,9 @@ consentNextButton:hover{
     .connectBodyPicture{
         text-align:center;
         height:150px;
+    }
+    .container{
+        padding-top: 1rem;
     }
 }
 @media (max-width:992px) and (min-width:521px){

--- a/js/pages/questionnaire.js
+++ b/js/pages/questionnaire.js
@@ -551,16 +551,16 @@ const displayQuestionnaire = (id, progressBar) => {
         rootElement.innerHTML = `
             ${progressBar ? `
             <div class="row" style="margin-top:50px">
-                <div class = "col-md-1">
+                <div class="col-md-1">
                 </div>
-                <div class = "col-md-10">
-                    <div class="progress" aria-label="Questionnaire Progress">
+                <div class="col-md-10">
+                    <div class="progress">
                         <div id="questProgBar" class="progress-bar" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
                             <span class="screen-reader-only" id="progressText">0% Complete</span>
                         </div>
                     </div>
                 </div>
-                <div class = "col-md-1">
+                <div class="col-md-1">
                 </div>
             </div>` : ''}
             <div class="row">


### PR DESCRIPTION
Related: https://github.com/episphere/connect/issues/1013

Fine-tuning the Quest container for screen readers (accessibility): 
• Update progress bar accessibility handling -> read percentage but skip reading enclosing container (navigation enhancement).
• Reduce whitespace around surveys for easier viewing & navigation -> especially in mobile view.