### PR TITLE
BSWH Samples Page Not Displaying

### DIFF
--- a/js/pages/samples.js
+++ b/js/pages/samples.js
@@ -1,5 +1,5 @@
 import { getMyData, hasUserData } from "../shared.js";
-import { conceptId } from '../fieldToConceptIdMapping.js';
+import conceptId from '../fieldToConceptIdMapping.js';
 
 export const renderSamplesPage = async () => {
     document.title = 'My Connect - Samples';


### PR DESCRIPTION
Problem: Named export used for `fieldToConceptIdMapping.js` instead of default export.

Code Change:
- remove curly braces to export as default export