### PR TITLE
BSWH add spacing to html consent form

### DIFF
--- a/forms/consent/BSWH_Consent_V0.02.html
+++ b/forms/consent/BSWH_Consent_V0.02.html
@@ -1195,7 +1195,7 @@
             class="s10" target="_blank">You may also contact the Principal Investigator, Nicolas Wentzensen, M.D., Ph.D., M.S. 
             at </a>ConnectPI@nih.gov or 240-276-7150.</p>
     <p style="padding-top: 5pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">For questions about your rights
-        while in this study, call the NIH Institutional Review Board at 301-402-3713.</p>
+        while in this study, call the NIH Institutional Review Board at 301-402-3713. </p> <br />
     <h1 style="padding-top: 3pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">CONSENT DOCUMENT</h1>
     <p style="padding-top: 5pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">Please keep a copy of this
         document in case you want to read it again. It can be viewed or downloaded from MyConnect after you sign up.</p>
@@ -1227,10 +1227,12 @@
     <p style="text-indent: 0pt;text-align: left;"><br /></p>
     <p style="padding-top: 10pt;padding-left: 20pt;text-indent: 0pt;line-height: 287%;text-align: left;">Please enter
         your legal name. </p>
-    <p style="padding-left: 20pt;text-indent: 0pt;text-align: left;">Name:</p>
-    <p style="padding-left: 20pt;text-indent: 0pt;text-align: left;">Date:</p>
+    <p style="padding-top: 10pt; padding-left: 20pt;text-indent: 0pt;text-align: left;">Name:</p>
+    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+    <p style="padding-top: 10pt; padding-left: 20pt;text-indent: 0pt;text-align: left;">Date:</p>
     <p style="text-indent: 0pt;text-align: left;"><br /></p>
     <p style="padding-top: 10pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">Signature:</p>
+    <br><br><br><br><br>
 </body>
 
 </html>

--- a/forms/consent/BSWH_Consent_V0.02.html
+++ b/forms/consent/BSWH_Consent_V0.02.html
@@ -261,16 +261,16 @@
     <p style="padding-top: 5pt;padding-left: 11pt;text-indent: 0pt;text-align: left;">
         <span class="s1">STUDY SITE: Baylor Scott and White Health</span>
     </p>
-    <p style="text-indent: 0pt;text-align: left;"><br /></p>
-    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+    <p style="text-indent: 0pt;text-align: left;"><br></p>
+    <p style="text-indent: 0pt;text-align: left;"><br></p>
     <hr/>
     <p style="padding-left: 11pt;text-indent: 0pt;text-align: left;">Cohort: People aged 30-70 who do not have a history
         of invasive cancer at enrollment (certain benign or precancers are acceptable)</p>
     <p style="padding-top: 5pt;padding-left: 11pt;text-indent: 0pt;text-align: left;">Consent Version: 02/13/2024 (V0.02)</p>
-    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+    <p style="text-indent: 0pt;text-align: left;"><br></p>
     <hr/>
     <h1 style="padding-top: 5pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">WHO DO YOU CONTACT ABOUT THIS STUDY?</h1>
-    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+    <p style="text-indent: 0pt;text-align: left;"><br></p>
     <table style="border-collapse:collapse;margin-left:20.77pt" cellspacing="0">
         <tr style="height:66pt">
             <td
@@ -301,11 +301,11 @@
             </td>
         </tr>
     </table>
-    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+    <p style="text-indent: 0pt;text-align: left;"><br></p>
     <h1 style="padding-top: 10pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">KEY INFORMATION ABOUT THIS
         RESEARCH</h1>
     <div style="border: 1px solid grey; margin:10pt 0;">
-        <p style="text-indent: 0pt;text-align: left;"><br /></p>
+        <p style="text-indent: 0pt;text-align: left;"><br></p>
         <p style="padding-left: 5pt;text-indent: 0pt;text-align: left;">This consent form describes a research study and is
             designed to help you decide if you would like to be a part of the research study. This study is taking place at
             more than one site.</p>
@@ -314,7 +314,7 @@
                 to you in making your decision about participating in this study. Additional information that may help you
                 decide can be found in other sections of the document. Taking part in research at Baylor Scott and White Health is your choice.</span>
         </p>
-        <p style="text-indent: 0pt;text-align: left;"><br /></p>
+        <p style="text-indent: 0pt;text-align: left;"><br></p>
     </div>
     <ul id="l1">
         <li data-list-text="■">
@@ -364,12 +364,12 @@
                 found below or on the Connect website (Cancer.gov/connectstudy).</p>
             <h1 style="padding-top: 6pt;padding-left: 11pt;text-indent: 0pt;text-align: left;">If you agree to join
                 Connect, we will ask you to:</h1>
-            <p style="text-indent: 0pt;text-align: left;"><br /></p>
+            <p style="text-indent: 0pt;text-align: left;"><br></p>
             <table style="border-collapse:collapse;margin-left:11.89pt" cellspacing="0">
                 <tr style="height:60pt">
                     <td
                         style="width:66pt;border-top-style:solid;border-top-width:1pt;border-left-style:solid;border-left-width:1pt;border-bottom-style:solid;border-bottom-width:1pt;border-right-style:solid;border-right-width:1pt">
-                        <p style="text-indent: 0pt;text-align: left;"><br /></p>
+                        <p style="text-indent: 0pt;text-align: left;"><br></p>
                         <p style="padding-left: 5pt;text-indent: 0pt;text-align: left;"><span>
                                 <table border="0" cellspacing="0" cellpadding="0">
                                     <tr>
@@ -395,7 +395,7 @@
                 <tr style="height:74pt">
                     <td
                         style="width:66pt;border-top-style:solid;border-top-width:1pt;border-left-style:solid;border-left-width:1pt;border-bottom-style:solid;border-bottom-width:1pt;border-right-style:solid;border-right-width:1pt">
-                        <p style="text-indent: 0pt;text-align: left;"><br /></p>
+                        <p style="text-indent: 0pt;text-align: left;"><br></p>
                         <p style="padding-left: 5pt;text-indent: 0pt;text-align: left;"><span>
                                 <table border="0" cellspacing="0" cellpadding="0">
                                     <tr>
@@ -422,7 +422,7 @@
                 <tr style="height:115pt">
                     <td
                         style="width:66pt;border-top-style:solid;border-top-width:1pt;border-left-style:solid;border-left-width:1pt;border-bottom-style:solid;border-bottom-width:1pt;border-right-style:solid;border-right-width:1pt">
-                        <p style="text-indent: 0pt;text-align: left;"><br /></p>
+                        <p style="text-indent: 0pt;text-align: left;"><br></p>
                         <p style="padding-left: 5pt;text-indent: 0pt;text-align: left;"><span>
                                 <table border="0" cellspacing="0" cellpadding="0">
                                     <tr>
@@ -486,7 +486,7 @@
                 <tr style="height:101pt">
                     <td
                         style="width:66pt;border-top-style:solid;border-top-width:1pt;border-left-style:solid;border-left-width:1pt;border-bottom-style:solid;border-bottom-width:1pt;border-right-style:solid;border-right-width:1pt">
-                        <p style="text-indent: 0pt;text-align: left;"><br /></p>
+                        <p style="text-indent: 0pt;text-align: left;"><br></p>
                         <p style="padding-left: 4pt;text-indent: 0pt;text-align: left;"><span>
                                 <table border="0" cellspacing="0" cellpadding="0">
                                     <tr>
@@ -514,7 +514,7 @@
                 <tr style="height:228pt">
                     <td
                         style="width:66pt;border-top-style:solid;border-top-width:1pt;border-left-style:solid;border-left-width:1pt;border-bottom-style:solid;border-bottom-width:1pt;border-right-style:solid;border-right-width:1pt">
-                        <p style="text-indent: 0pt;text-align: left;"><br /></p>
+                        <p style="text-indent: 0pt;text-align: left;"><br></p>
                         <p style="padding-left: 8pt;text-indent: 0pt;text-align: left;"><span>
                                 <table border="0" cellspacing="0" cellpadding="0">
                                     <tr>
@@ -561,7 +561,7 @@
                 </tr>
             </table>
             
-            <p style="text-indent: 0pt;text-align: left;"><br /></p>
+            <p style="text-indent: 0pt;text-align: left;"><br></p>
             <p style="padding-top: 4pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">The remaining document
                 will describe the research study in more detail. Please consider this information before deciding if you
                 want to join the study. Members of the study team can talk with you about the information in this
@@ -570,7 +570,7 @@
                 or research studies in which they would want to participate. Take the time you need to ask any questions
                 and discuss this study with the Connect Support Center (Cancer.gov/connectstudy/support), and with your
                 family, friends, and personal health care providers.</p>
-            <p style="text-indent: 0pt;text-align: left;"><br /></p>
+            <p style="text-indent: 0pt;text-align: left;"><br></p>
             <h1 style="padding-top: 11pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">IT IS YOUR CHOICE TO
                 TAKE PART IN THE STUDY</h1>
             <p style="padding-top: 5pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">You may choose not to take
@@ -597,7 +597,7 @@
                 Before you sign up for this study or at any time during the research, you may discuss your care with 
                 another doctor who is not associated with this research project. You are not under any obligation to take part in 
                 any research study offered by your doctor.</p>
-            <p style="text-indent: 0pt;text-align: left;"><br /></p>
+            <p style="text-indent: 0pt;text-align: left;"><br></p>
             <h1 style="padding-top: 10pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">WHY IS THIS STUDY BEING
                 DONE?</h1>
             <p style="padding-top: 5pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">The Connect for Cancer
@@ -620,7 +620,7 @@
             <p style="padding-top: 6pt;padding-left: 20pt;text-indent: 3pt;text-align: left;">If you are unsure if you
                 can join based on a diagnosis now or in the past, please contact the Connect Support Center
                 (Cancer.gov/connectstudy/support).</p>
-            <p style="text-indent: 0pt;text-align: left;"><br /></p>
+            <p style="text-indent: 0pt;text-align: left;"><br></p>
             <h1 style="padding-top: 10pt;padding-left: 20pt;text-indent: 0pt;text-align: justify;">WHAT WILL HAPPEN
                 DURING THE STUDY?</h1>
             <p style="padding-top: 5pt;padding-left: 20pt;text-indent: 0pt;text-align: justify;">If you decide to
@@ -734,7 +734,7 @@
                         health-related information), we may ask if you would share data with us. We may send you
                         separate devices (like a fitness tracker or air pollution monitor) to collect information for
                         Connect.</p>
-                    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+                    <p style="text-indent: 0pt;text-align: left;"><br></p>
                     <h1 style="padding-top: 10pt;padding-left: 20pt;text-indent: 0pt;text-align: justify;">HOW WILL YOU
                         CONTACT ME?</h1>
                     <p style="padding-top: 5pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">The Connect team
@@ -743,7 +743,7 @@
                         contact with you, we will try to reach you in other ways. For example, we may look in your
                         medical record or reach out to backup contact(s) that you give us. We may also check public
                         listings to help us find your up-to-date contact information.</p>
-                    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+                    <p style="text-indent: 0pt;text-align: left;"><br></p>
                     <h1 style="padding-top: 11pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">WHAT WILL YOU DO
                         WITH MY INFORMATION AND SPECIMENS?</h1>
                     <p style="padding-top: 5pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">We value the time,
@@ -811,7 +811,7 @@
                             find precancer or early signs of cancer to better understand how cancer develops and how to
                             find cancers earlier. These and other specimens, like stool, allow researchers to look at
                             changes over time.</span></h1>
-                    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+                    <p style="text-indent: 0pt;text-align: left;"><br></p>
                     <h1 style="padding-top: 11pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">GENOMIC
                         SEQUENCING</h1>
                     <p style="padding-top: 5pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">We are requesting
@@ -840,7 +840,7 @@
                         insurance, disability insurance, or long-term care insurance. GINA also does not protect you
                         against discrimination based on an already-diagnosed condition or disease that has a genetic
                         component.</p>
-                    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+                    <p style="text-indent: 0pt;text-align: left;"><br></p>
                     <h1 style="padding-top: 11pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">HOW LONG WILL
                         THE STUDY TAKE?</h1>
                     <p style="padding-top: 5pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">If you join
@@ -848,12 +848,12 @@
                         to watch things that can change over a person’s lifetime, such as habits like diet and exercise,
                         and the environment. Some of these may affect the risk of cancer and other health problems. The
                         information and specimens will be used for research for many years into the future.</p>
-                    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+                    <p style="text-indent: 0pt;text-align: left;"><br></p>
                     <h1 style="padding-top: 11pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">HOW MANY PEOPLE
                         WILL PARTICIPATE IN THIS STUDY?</h1>
                     <p style="padding-top: 6pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">We plan to include
                         200,000 people in Connect.</p>
-                    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+                    <p style="text-indent: 0pt;text-align: left;"><br></p>
                     <h1 style="padding-top: 10pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">WHAT ARE THE
                         RISKS AND DISCOMFORTS OF BEING IN THE STUDY?</h1>
                     <p style="padding-top: 5pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">Connect activities
@@ -887,7 +887,7 @@
                     <h1 style="padding-top: 5pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">Unused
                         specimens<span class="p">. No risks or discomforts are expected from storing these specimens for
                             Connect research purposes.</span></h1>
-                    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+                    <p style="text-indent: 0pt;text-align: left;"><br></p>
                     <h1 style="padding-top: 10pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">WHAT ARE THE
                         BENEFITS OF BEING IN THE STUDY?</h1>
                     <p style="padding-top: 5pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">You will not
@@ -901,13 +901,13 @@
                     <p style="padding-left: 20pt;text-indent: 0pt;text-align: left;">However, your participation is very
                         important and could contribute to our understanding of the prevention and treatment of cancer
                         and other discoveries.</p>
-                    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+                    <p style="text-indent: 0pt;text-align: left;"><br></p>
                     <h1 style="padding-top: 10pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">WHAT OTHER
                         OPTIONS ARE THERE FOR YOU?</h1>
                     <p style="padding-top: 5pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">You can choose to
                         not join Connect. There may be other studies looking at the causes of cancer and ways to prevent
                         cancer in healthy individuals that you may choose to join.</p>
-                    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+                    <p style="text-indent: 0pt;text-align: left;"><br></p>
                     <h1 style="padding-top: 10pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">DISCUSSION OF
                         FINDINGS</h1>
                     <h1 style="padding-top: 6pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">New information
@@ -953,7 +953,7 @@
                             you choose to receive your results, Connect will have a plan to help you understand them.
                             Connect will also help you understand the meaning of your results for your health and your
                             family’s health.</span></h1>
-                    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+                    <p style="text-indent: 0pt;text-align: left;"><br></p>
                     <h1 style="padding-top: 11pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">EARLY WITHDRAWAL
                         FROM THE STUDY</h1>
                     <p style="padding-top: 5pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">If you agree to
@@ -963,7 +963,7 @@
                         otherwise participate in Connect, we may stop contacting you. We may still collect data from
                         your health and medical records or other data sources even after we stop contacting you. No
                         action will be needed on your part if this happens.</p>
-                    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+                    <p style="text-indent: 0pt;text-align: left;"><br></p>
                     <h1 style="padding-top: 10pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">STORAGE, SHARING
                         AND FUTURE RESEARCH USING YOUR SPECIMENS AND DATA</h1>
                     <h1 style="padding-top: 5pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">Will your
@@ -1041,7 +1041,7 @@
                         you. Even with the safeguards we put in place, we cannot guarantee that your identity will never
                         become known or someone may gain unauthorized access to your information. New methods may be
                         created in the future that could make it possible to re-identify your specimens and data.</p>
-                    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+                    <p style="text-indent: 0pt;text-align: left;"><br></p>
                     <h1 style="padding-top: 11pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">PAYMENT</h1>
                     <h1 style="padding-top: 6pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">Will you receive
                         any type of payment for taking part in the study?</h1>
@@ -1071,7 +1071,7 @@
         answer more surveys and donate more specimens. We may provide payment for some of these future activities. We
         will tell you the amount and form of payment when we invite you to do these activities. Plans for future payment
         may change over time and vary by location.</p>
-    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+    <p style="text-indent: 0pt;text-align: left;"><br></p>
     <h1 style="padding-top: 10pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">COSTS</h1>
     <h1 style="padding-top: 5pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">Will taking part in this research
         study cost you anything?</h1>
@@ -1080,7 +1080,7 @@
         or postage for mailing). If you are contacted by text message, you will be charged standard rates. <u>Connect
             will not cover medical</u> <u>care costs</u>. Your doctor will continue to be responsible for your medical
         care.</p>
-    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+    <p style="text-indent: 0pt;text-align: left;"><br></p>
     <h1 style="padding-top: 4pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">CLINICAL TRIAL REGISTRATION AND
         RESULTS REPORTING</h1>
     <p style="padding-top: 5pt;padding-left: 20pt;text-indent: 0pt;text-align: left;"><a
@@ -1091,7 +1091,7 @@
         this Web site at any time.</p>
     <p style="padding-top: 3pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">You can also visit the study
         website (Cancer.gov/connectstudy) for further information about the study.</p>
-    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+    <p style="text-indent: 0pt;text-align: left;"><br></p>
     <h1 style="padding-top: 10pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">CONFIDENTIALITY PROTECTIONS
         PROVIDED IN THIS STUDY</h1>
     <h1 style="padding-top: 6pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">Will your medical information be
@@ -1186,7 +1186,7 @@
     <p style="padding-left: 20pt;text-indent: 0pt;text-align: left;">However, NIH will only release information from
         your medical record if it is permitted by both the Certificate of Confidentiality and the Privacy Act. If you do
         not want to share your information with us, then you cannot participate in this study.</p>
-    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+    <p style="text-indent: 0pt;text-align: left;"><br></p>
     <h1 style="padding-top: 10pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">PROBLEMS OR QUESTIONS</h1>
     <p style="padding-top: 5pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">If you have any problems or
         questions about this study, or about your rights as a research participant, or about any research-related
@@ -1195,11 +1195,11 @@
             class="s10" target="_blank">You may also contact the Principal Investigator, Nicolas Wentzensen, M.D., Ph.D., M.S. 
             at </a>ConnectPI@nih.gov or 240-276-7150.</p>
     <p style="padding-top: 5pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">For questions about your rights
-        while in this study, call the NIH Institutional Review Board at 301-402-3713. </p> <br />
+        while in this study, call the NIH Institutional Review Board at 301-402-3713. </p> <br>
     <h1 style="padding-top: 3pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">CONSENT DOCUMENT</h1>
     <p style="padding-top: 5pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">Please keep a copy of this
         document in case you want to read it again. It can be viewed or downloaded from MyConnect after you sign up.</p>
-    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+    <p style="text-indent: 0pt;text-align: left;"><br></p>
     <h1 style="padding-top: 10pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">By clicking “Yes, I agree to
         join Connect” and typing your name, you confirm the following:</h1>
     <ol id="l7">
@@ -1221,16 +1221,16 @@
                 contact the Connect Support Center at Cancer.gov/connectstudy/support.</p>
         </li>
     </ol>
-    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+    <p style="text-indent: 0pt;text-align: left;"><br></p>
     <h1 style="padding-top: 9pt;padding-left: 172pt;text-indent: 0pt;text-align: center;">[X] Yes, I agree to join
         Connect</h1>
-    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+    <p style="text-indent: 0pt;text-align: left;"><br></p>
     <p style="padding-top: 10pt;padding-left: 20pt;text-indent: 0pt;line-height: 287%;text-align: left;">Please enter
         your legal name. </p>
     <p style="padding-top: 10pt; padding-left: 20pt;text-indent: 0pt;text-align: left;">Name:</p>
-    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+    <p style="text-indent: 0pt;text-align: left;"><br></p>
     <p style="padding-top: 10pt; padding-left: 20pt;text-indent: 0pt;text-align: left;">Date:</p>
-    <p style="text-indent: 0pt;text-align: left;"><br /></p>
+    <p style="text-indent: 0pt;text-align: left;"><br></p>
     <p style="padding-top: 10pt;padding-left: 20pt;text-indent: 0pt;text-align: left;">Signature:</p>
     <br><br><br><br><br>
 </body>


### PR DESCRIPTION
This PR is related to the issue:
- https://github.com/episphere/connect/issues/885

issue comment:
- https://github.com/episphere/connect/issues/885#issuecomment-2129925138 (4 & 5)
- https://github.com/episphere/connect/issues/885#issuecomment-2142669553
 
- Add to areas of BSWH HTML consent form, "space/blank line between phone number and consent document to separate these out some" and "between date and signature"
 
Code changes
- Add spacing using `<br>` element

![Screenshot 2024-05-31 at 4 28 10 PM](https://github.com/episphere/connectApp/assets/33293205/0456534a-f50c-48f4-b383-ca573607b60c)
![Screenshot 2024-05-31 at 4 28 13 PM](https://github.com/episphere/connectApp/assets/33293205/b343fe0f-0048-48ec-8446-d929ba0427e8)

