### PR TITLE
Reference Language-Specific Markdown

### DIFF
--- a/js/fieldToConceptIdMapping.js
+++ b/js/fieldToConceptIdMapping.js
@@ -71,6 +71,8 @@ export default
         "es": 773342525
     },
 
+    surveyLanguage: 784119588,
+
     "heardAboutStudyForm" : 142654897,
 
     "heardAboutStudyCheckBoxes":{

--- a/js/pages/myToDoList.js
+++ b/js/pages/myToDoList.js
@@ -737,37 +737,7 @@ const setModuleAttributes = (data, modules, collections) => {
     modules['PROMIS'].header = 'Quality of Life Survey';
     modules['PROMIS'].description = 'mytodolist.mainBodyPROMISDescription';
     modules['PROMIS'].estimatedTime = 'mytodolist.10_15minutes';
-    if (modules['Spanish Covid-19']) {
-        modules['Spanish Covid-19'].header = 'SPANISH COVID-19 Survey';
-        modules['Spanish Covid-19'].description = 'mytodolist.mainBodyCovid19Description';
-        modules['Spanish Covid-19'].hasIcon = false;
-        modules['Spanish Covid-19'].noButton = false;
-        modules['Spanish Covid-19'].estimatedTime = 'mytodolist.10minutes';
-    }
     
-    if (modules['Spanish Biospecimen Survey']) {
-        modules['Spanish Biospecimen Survey'].header = 'SPANISH Baseline Blood, Urine, and Mouthwash Sample Survey';
-        modules['Spanish Biospecimen Survey'].description = 'mytodolist.mainBodyBiospecimenDescription';
-        modules['Spanish Biospecimen Survey'].estimatedTime = 'mytodolist.5minutes';
-    }
-    
-    if (modules['Spanish Clinical Biospecimen Survey']) {
-        modules['Spanish Clinical Biospecimen Survey'].header = 'SPANISH Clinical Baseline Blood and Urine Sample Survey';
-        modules['Spanish Clinical Biospecimen Survey'].description = 'mytodolist.mainBodyClinicalBiospecimenDescription';
-        modules['Spanish Clinical Biospecimen Survey'].estimatedTime = 'mytodolist.5minutes';
-    }
-    
-    if (modules['Spanish Menstrual Cycle']) {
-        modules['Spanish Menstrual Cycle'].header = 'SPANISH Menstrual Cycle Survey';
-        modules['Spanish Menstrual Cycle'].description = 'mytodolist.mainBodyMenstrualDescription';
-        modules['Spanish Menstrual Cycle'].estimatedTime = 'mytodolist.5minutes';
-    }
-    
-    if (modules['Spanish Mouthwash']) {
-        modules['Spanish Mouthwash'].header = 'SPANISH At-Home Mouthwash Sample Survey';
-        modules['Spanish Mouthwash'].description = 'mytodolist.mainBodyMouthwashDescription';
-        modules['Spanish Mouthwash'].estimatedTime = 'mytodolist.5minutes';
-    }
     if(data['331584571']?.['266600170']?.['840048338']) {
         modules['Biospecimen Survey'].enabled = true;
         modules['Covid-19'].enabled = true;

--- a/js/pages/questionnaire.js
+++ b/js/pages/questionnaire.js
@@ -132,6 +132,7 @@ async function startModule(data, modules, moduleId, questDiv) {
     let path;
     let sha;
     let key;
+    let lang;
 
     try {
         inputData = setInputData(data, modules); 
@@ -152,7 +153,7 @@ async function startModule(data, modules, moduleId, questDiv) {
         // Module has not been started.
         if (data[fieldMapping[moduleId].statusFlag] === fieldMapping.moduleStatus.notStarted) {
             
-            path = getMarkdownPath(appState.getState().language, moduleConfig[key]);
+            ({ path, lang } = getMarkdownPath(appState.getState().language, moduleConfig[key]));
             
             try {
                 sha = await fetchDataWithRetry(() => getModuleSHA(path, data['Connect_ID'], moduleId));
@@ -170,7 +171,7 @@ async function startModule(data, modules, moduleId, questDiv) {
         // Module has been started and has a SHA value.
         } else if (modules[fieldMapping[moduleId].conceptId]?.['sha']) {
 
-            path = getMarkdownPath(modules[fieldMapping[moduleId].conceptId][fieldMapping.surveyLanguage], moduleConfig[key]);
+            ({ path, lang } = getMarkdownPath(modules[fieldMapping[moduleId].conceptId][fieldMapping.surveyLanguage], moduleConfig[key]));
 
             sha = modules[fieldMapping[moduleId].conceptId]['sha'];
             url += sha + "/" + path;
@@ -179,7 +180,7 @@ async function startModule(data, modules, moduleId, questDiv) {
         } else {
             const startSurveyTimestamp = data[fieldMapping[moduleId].startTs] || '';
 
-            path = getMarkdownPath(modules[fieldMapping[moduleId].conceptId][fieldMapping.surveyLanguage], moduleConfig[key]);
+            ({ path, lang } = getMarkdownPath(modules[fieldMapping[moduleId].conceptId][fieldMapping.surveyLanguage], moduleConfig[key]));
 
             // Get the SHA from the GitHub API. The correct SHA is the SHA for the active survey commit when the participant started the survey.
             let surveyVersion;
@@ -208,7 +209,8 @@ async function startModule(data, modules, moduleId, questDiv) {
             retrieve: function(){return getMySurveys([fieldMapping[moduleId].conceptId], true)},
             soccer: externalListeners,
             updateTree: storeResponseTree,
-            treeJSON: tJSON
+            treeJSON: tJSON,
+            lang: lang
         }
 
         window.scrollTo(0, 0);
@@ -609,17 +611,20 @@ const displayError = () => {
 const getMarkdownPath = (value, config) => {
     
     let path;
+    let lang;
     
     switch (value) {
         case fieldMapping.language.en:
             path = config.path.en;
+            lang = 'en';
             break;
         case fieldMapping.language.es:
             path = config.path.es;
+            lang = 'es';
             break;
         default:
             throw new Error('Error: Language not defined in App State.');
     }
 
-    return path;
+    return { path, lang };
 }

--- a/js/pages/questionnaire.js
+++ b/js/pages/questionnaire.js
@@ -1,4 +1,4 @@
-import { getModuleSHA, getMyData, getShaFromGitHubCommitData, hasUserData, getMySurveys, logDDRumError, urls, questionnaireModules, storeResponseQuest, storeResponseTree, showAnimation, hideAnimation, addEventReturnToDashboard, fetchDataWithRetry, updateStartSurveyParticipantData } from "../shared.js";
+import { getModuleSHA, getMyData, getShaFromGitHubCommitData, hasUserData, getMySurveys, logDDRumError, urls, questionnaireModules, storeResponseQuest, storeResponseTree, showAnimation, hideAnimation, addEventReturnToDashboard, fetchDataWithRetry, updateStartSurveyParticipantData, appState } from "../shared.js";
 import fieldMapping from '../fieldToConceptIdMapping.js'; 
 import { socialSecurityTemplate } from "./ssn.js";
 import { SOCcer as SOCcerProd } from "./../../prod/config.js";
@@ -138,10 +138,8 @@ async function startModule(data, modules, moduleId, questDiv) {
         moduleConfig = questionnaireModules();
 
         key = Object.keys(moduleConfig).find(key => moduleConfig[key].moduleId === moduleId);
-        
-        if (key) {
-            path = moduleConfig[key].path;
-        } else {
+
+        if (!key) {
             throw new Error('Error: No path found for module (null key).');
         }
 
@@ -153,6 +151,9 @@ async function startModule(data, modules, moduleId, questDiv) {
 
         // Module has not been started.
         if (data[fieldMapping[moduleId].statusFlag] === fieldMapping.moduleStatus.notStarted) {
+            
+            path = getMarkdownPath(appState.getState().language, moduleConfig[key]);
+            
             try {
                 sha = await fetchDataWithRetry(() => getModuleSHA(path, data['Connect_ID'], moduleId));
                 url += sha + "/" + path;
@@ -168,12 +169,17 @@ async function startModule(data, modules, moduleId, questDiv) {
 
         // Module has been started and has a SHA value.
         } else if (modules[fieldMapping[moduleId].conceptId]?.['sha']) {
+
+            path = getMarkdownPath(modules[fieldMapping[moduleId].conceptId][fieldMapping.surveyLanguage], moduleConfig[key]);
+
             sha = modules[fieldMapping[moduleId].conceptId]['sha'];
             url += sha + "/" + path;
 
         // Module has been started but SHA is not found. 'Fix' the case where the SHA is not found for the module.
         } else {
             const startSurveyTimestamp = data[fieldMapping[moduleId].startTs] || '';
+
+            path = getMarkdownPath(modules[fieldMapping[moduleId].conceptId][fieldMapping.surveyLanguage], moduleConfig[key]);
 
             // Get the SHA from the GitHub API. The correct SHA is the SHA for the active survey commit when the participant started the survey.
             let surveyVersion;
@@ -199,7 +205,7 @@ async function startModule(data, modules, moduleId, questDiv) {
             activate: true,
             delayedParameterArray: fieldMapping.delayedParameterArray, // Delayed parameters (external questions that require extra processing time)
             store: storeResponseQuest,
-            retrieve: function(){return getMySurveys([fieldMapping[moduleId].conceptId])},
+            retrieve: function(){return getMySurveys([fieldMapping[moduleId].conceptId], true)},
             soccer: externalListeners,
             updateTree: storeResponseTree,
             treeJSON: tJSON
@@ -598,4 +604,22 @@ const displayError = () => {
     window.scrollTo(0, 0);
 
     hideAnimation();
+}
+
+const getMarkdownPath = (value, config) => {
+    
+    let path;
+    
+    switch (value) {
+        case fieldMapping.language.en:
+            path = config.path.en;
+            break;
+        case fieldMapping.language.es:
+            path = config.path.es;
+            break;
+        default:
+            throw new Error('Error: Language not defined in App State.');
+    }
+
+    return path;
 }

--- a/js/shared.js
+++ b/js/shared.js
@@ -300,7 +300,7 @@ export const successResponse = (response) => {
     return response.code === 200
 }
 
-export const getMySurveys = async (data) => {
+export const getMySurveys = async (data, filter = false) => {
     
     const idToken = await getIdToken();
     const response = await fetch(`${api}?api=getUserSurveys`, {
@@ -330,7 +330,13 @@ export const getMySurveys = async (data) => {
                 if(surveyData.data[survey][versionNumber]) {
                     delete surveyData.data[survey][versionNumber];
                 }
-            })
+            });
+
+            if (filter) {
+                if (surveyData.data[survey][fieldMapping.surveyLanguage]) {
+                    delete surveyData.data[survey][fieldMapping.surveyLanguage];
+                }
+            }
         })
     }
 
@@ -1034,39 +1040,91 @@ export const questionnaireModules = () => {
         }
     }
 
-    if (location.host === urls.dev || location.host === 'localhost:5000') {
-        return {
-            'Background and Overall Health': {path: 'module1Stage.txt', moduleId:"Module1", enabled:true},
-            'Medications, Reproductive Health, Exercise, and Sleep': {path: 'module2Stage.txt', moduleId:"Module2", enabled:false},
-            'Smoking, Alcohol, and Sun Exposure': {path: 'module3Stage.txt', moduleId:"Module3", enabled:false},
-            'Where You Live and Work': {path: 'module4Stage.txt', moduleId:"Module4", enabled:false},
-            'Enter SSN': {moduleId:"ModuleSsn", enabled:false},
-            'Covid-19': {path: 'moduleCOVID19Stage.txt', moduleId:"ModuleCovid19", enabled:false},
-            'Biospecimen Survey': {path: 'moduleBiospecimenStage.txt', moduleId:"Biospecimen", enabled:false},
-            'Clinical Biospecimen Survey': {path: 'moduleClinicalBloodUrineStage.txt', moduleId:"ClinicalBiospecimen", enabled:false},
-            'Menstrual Cycle': {path: 'moduleMenstrualStage.txt', moduleId:"MenstrualCycle", enabled:false},
-            'Mouthwash': {path: 'moduleMouthwash.txt', moduleId:"Mouthwash", enabled:false},
-            'PROMIS': {path: 'moduleQoL.txt', moduleId:"PROMIS", enabled:false},
-            'Spanish Covid-19': {path: 'moduleCOVID19StageSpanish.txt', moduleId:"ModuleCovid19Spanish", enabled:true},
-            'Spanish Biospecimen Survey': {path: 'moduleBiospecimenStageSpanish.txt', moduleId:"BiospecimenSpanish", enabled:true},
-            'Spanish Clinical Biospecimen Survey': {path: 'moduleClinicalBloodUrineStageSpanish.txt', moduleId:"ClinicalBiospecimenSpanish", enabled:true},
-            'Spanish Menstrual Cycle': {path: 'moduleMenstrualStageSpanish.txt', moduleId:"MenstrualCycleSpanish", enabled:true},
-            'Spanish Mouthwash': {path: 'moduleMouthwashSpanish.txt', moduleId:"MouthwashSpanish", enabled:true}
-        };
-    }
-
     return {
-        'Background and Overall Health': {path: 'module1Stage.txt', moduleId:"Module1", enabled:true},
-        'Medications, Reproductive Health, Exercise, and Sleep': {path: 'module2Stage.txt', moduleId:"Module2", enabled:false},
-        'Smoking, Alcohol, and Sun Exposure': {path: 'module3Stage.txt', moduleId:"Module3", enabled:false},
-        'Where You Live and Work': {path: 'module4Stage.txt', moduleId:"Module4", enabled:false},
-        'Enter SSN': {moduleId:"ModuleSsn", enabled:false},
-        'Covid-19': {path: 'moduleCOVID19Stage.txt', moduleId:"ModuleCovid19", enabled:false},
-        'Biospecimen Survey': {path: 'moduleBiospecimenStage.txt', moduleId:"Biospecimen", enabled:false},
-        'Clinical Biospecimen Survey': {path: 'moduleClinicalBloodUrineStage.txt', moduleId:"ClinicalBiospecimen", enabled:false},
-        'Menstrual Cycle': {path: 'moduleMenstrualStage.txt', moduleId:"MenstrualCycle", enabled:false},
-        'Mouthwash': {path: 'moduleMouthwash.txt', moduleId:"Mouthwash", enabled:false},
-        'PROMIS': {path: 'moduleQoL.txt', moduleId:"PROMIS", enabled:false}
+        'Background and Overall Health': {
+            path: {
+                en: 'module1Stage.txt',
+                es: 'module1StageSpanish.txt'
+            }, 
+            moduleId:"Module1", 
+            enabled:true
+        },
+        'Medications, Reproductive Health, Exercise, and Sleep': {
+            path: {
+                en: 'module2Stage.txt',
+                es: 'module2StageSpanish.txt'
+            }, 
+            moduleId:"Module2", 
+            enabled:false
+        },
+        'Smoking, Alcohol, and Sun Exposure': {
+            path: {
+                en: 'module3Stage.txt',
+                es: 'module3StageSpanish.txt'
+            }, 
+            moduleId:"Module3", 
+            enabled:false
+        },
+        'Where You Live and Work': {
+            path: {
+                en: 'module4Stage.txt',
+                es: 'module4StageSpanish.txt'
+            }, 
+            moduleId:"Module4", 
+            enabled:false
+        },
+        'Enter SSN': {
+            moduleId:"ModuleSsn", 
+            enabled:false
+        },
+        'Covid-19': {
+            path: {
+                en: 'moduleCOVID19Stage.txt',
+                es: 'moduleCOVID19StageSpanish.txt'
+            }, 
+            moduleId:"ModuleCovid19", 
+            enabled:false
+        },
+        'Biospecimen Survey': {
+            path: {
+                en: 'moduleBiospecimenStage.txt',
+                es: 'moduleBiospecimenStageSpanish.txt'
+            }, 
+            moduleId:"Biospecimen", 
+            enabled:false
+        },
+        'Clinical Biospecimen Survey': {
+            path: {
+                en: 'moduleClinicalBloodUrineStage.txt',
+                es: 'moduleClinicalBloodUrineStageSpanish.txt'
+            }, 
+            moduleId:"ClinicalBiospecimen", 
+            enabled:false
+        },
+        'Menstrual Cycle': {
+            path: {
+                en: 'moduleMenstrualStage.txt',
+                es: 'moduleMenstrualStageSpanish.txt'
+            }, 
+            moduleId:"MenstrualCycle", 
+            enabled:false
+        },
+        'Mouthwash': {
+            path: {
+                en: 'moduleMouthwash.txt',
+                es: 'moduleMouthwashSpanish.txt'
+            }, 
+            moduleId:"Mouthwash", 
+            enabled:false
+        },
+        'PROMIS': {
+            path: {
+                en: 'moduleQoL.txt',
+                es: 'moduleQoLSpanish.txt'
+            }, 
+            moduleId:"PROMIS", 
+            enabled:false
+        }
     };
 }
 
@@ -1668,6 +1726,7 @@ export const updateStartSurveyParticipantData = async (sha, url, moduleId, repai
 
         questData[fieldMapping[moduleId].conceptId + ".sha"] = sha;
         questData[fieldMapping[moduleId].conceptId + "." + fieldMapping[moduleId].version] = version;
+        questData[fieldMapping[moduleId].conceptId + "." + fieldMapping.surveyLanguage] = appState.getState().language;
 
         // Do not update startTs if the sha is being repaired. Retain the original startTs, which coincides with the fetched survey.
         if (!repairShaValue) formData[fieldMapping[moduleId].startTs] = new Date().toISOString();


### PR DESCRIPTION
This PR addresses the following Issue:
* https://github.com/episphere/connect/issues/915
-----
## Background Details
* Now that Spanish has been added as a language to the PWA we need to render the correct markdown file depending on which language the participant is using. If a participant starts a survey in one language, they must finish the survey in that language.
-----
## Technical Changes
* added constant to `fieldToConceptIdmapping.js`
* added function `getMarkdownPath()` to `questionnaire.js`
  * if a survey hasn't been started, use the language currently being used on the PWA
  * if a survey has already been started, use the language the survey was previously started in
* added parameter `filter` to function `getMySurveys()`
  * used to filter CID fields we want to be able to read in the PWA but won't have a corresponding Question ID in the markdown
  * if there isn't a corresponding Question ID, Quest throws an error