### PR TITLE
`assert` Bug Fix

### DIFF
--- a/js/shared.js
+++ b/js/shared.js
@@ -2,8 +2,8 @@ import { addEventHideNotification } from "./event.js";
 import fieldMapping from './fieldToConceptIdMapping.js'; 
 import { signInConfig } from "./pages/signIn.js";
 import { signInCheckRender, signUpRender } from "./pages/homePage.js";
-import en from "../i18n/en.json" assert {type: 'json'};
-import es from "../i18n/es.json" assert {type: 'json'};
+import en from "../i18n/en.json" with {type: 'json'};
+import es from "../i18n/es.json" with {type: 'json'};
 
 const i18n = {
     es, en


### PR DESCRIPTION
This PR addresses the following Issue:
* N/A
-----
## Background Details
* use of keyword `assert` when importing JSON files in code is not supported anymore in some browsers
-----
## Technical Changes
* replacing `assert` keyword with `with`