### PR TITLE
Browser Import Bug

### DIFF
--- a/i18n/en.js
+++ b/i18n/en.js
@@ -1,4 +1,4 @@
-{
+const en = {
     "home": {
         "titleText": "Connect <em>today.</em><br>Prevent cancer<br><em>tomorrow.</em><br /><br /><img src=\"./images/newImages/ConnectLogo.png\" alt=\"Connect logo\"><br><br>",
         "ageQuestion": "<b>Are you age 30 to 70 with no history of certain cancers?*</b>",
@@ -1640,3 +1640,5 @@
         "spanishOption": "Español"
     }
 }
+
+export default en;

--- a/i18n/es.js
+++ b/i18n/es.js
@@ -1,4 +1,4 @@
-﻿{
+﻿const es ={
     "home": {
         "titleText": "Súmese a Connect <em>hoy.</em><br/>Prevenga el cáncer<br/><em>mañana.</em><br/><br/><img src=\"./images/newImages/ConnectLogo.png\" alt=\"Logotipo de Connect\"/><br/><br/>",
         "ageQuestion": "<b>¿Tiene entre 30 y 70 años, y no tiene antecedentes de ciertos tipos de cáncer?*</b>",
@@ -1644,3 +1644,5 @@
         "spanishOption": "Español"
     }
 }
+
+export default es;

--- a/js/shared.js
+++ b/js/shared.js
@@ -2,8 +2,8 @@ import { addEventHideNotification } from "./event.js";
 import fieldMapping from './fieldToConceptIdMapping.js'; 
 import { signInConfig } from "./pages/signIn.js";
 import { signInCheckRender, signUpRender } from "./pages/homePage.js";
-import en from "../i18n/en.json" with {type: 'json'};
-import es from "../i18n/es.json" with {type: 'json'};
+import en from "../i18n/en.js";
+import es from "../i18n/es.js";
 
 const i18n = {
     es, en


### PR DESCRIPTION
This PR addresses the following Issue:
* N/A
-----
## Background Details
* Firefox doesn't support assertions when importing files so the code was breaking when trying to import the local JSON files for i18n logic. The best solution I found to keep the process of accessing these files synchronous was to convert the JSON files to JS then export the object from the file.
-----
## Technical Changes
* Renamed `es.json` and `en.json` to `es.js` and `en.js`
* Updated references to files