### PR TITLE
Temporarily Disable Spanish

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,10 +43,13 @@ window.onload = async () => {
     }
 
     //Check for language storage
-    let preferredLanguage = window.localStorage.getItem('preferredLanguage');
-    if (!preferredLanguage) {
-        preferredLanguage = conceptIdMap.language.en;
-    }
+    // temp hardcoding for English - 061024
+    // let preferredLanguage = window.localStorage.getItem('preferredLanguage');
+    // if (!preferredLanguage) {
+    //     preferredLanguage = conceptIdMap.language.en;
+    // }
+
+    const preferredLanguage = conceptIdMap.language.en;
     appState.setState({"language": parseInt(preferredLanguage, 10)});
 
     const script = document.createElement('script');
@@ -206,10 +209,13 @@ const router = async () => {
     let exceptions = ['#joining-connect','#after-you-join','#long-term-study-activities','#what-connect-will-do','#how-your-information-will-help-prevent-cancer','#why-connect-is-important','#what-to-expect-if-you-decide-to-join','#where-this-study-takes-place','#about-our-researchers','#a-resource-for-science']
     if (loggedIn === false) {
         toggleNavBar(route, {}); // If not logged in, pass no data to toggleNavBar
-        const languageSelectorContainer = document.getElementById('languageSelectorContainer');
-        languageSelectorContainer.innerHTML = languageSelector();
-        translateHTML(languageSelectorContainer);
-        addEventLanguageSelection();
+
+        // temp disable - 061024
+        // const languageSelectorContainer = document.getElementById('languageSelectorContainer');
+        // languageSelectorContainer.innerHTML = languageSelector();
+        // translateHTML(languageSelectorContainer);
+        // addEventLanguageSelection();
+
         if (route === '#') {
             homePage();
         } else if (route === '#about') {
@@ -230,8 +236,11 @@ const router = async () => {
     }
     else{
         const data = await getMyData();
-        document.getElementById('languageSelectorContainer').innerHTML = languageSelector(data);
-        addEventLanguageSelection();
+
+        // temp disable - 061024
+        // document.getElementById('languageSelectorContainer').innerHTML = languageSelector(data);
+        // addEventLanguageSelection();
+        
         if(successResponse(data)) {
             const firebaseAuthUser = firebase.auth().currentUser;
             await checkAuthDataConsistency(firebaseAuthUser.email ?? '', firebaseAuthUser.phoneNumber ?? '', data.data[conceptIdMap.firebaseAuthEmail] ?? '', data.data[conceptIdMap.firebaseAuthPhone] ?? '');

--- a/js/pages/consent.js
+++ b/js/pages/consent.js
@@ -1065,7 +1065,8 @@ const consentSubmit = async e => {
     formData['507120821'] = 596523216;
 
     //set the prefered language
-    formData[fieldMapping.preferredLanguage] = selectedLanguage;
+    // temp disable - 061024
+    // formData[fieldMapping.preferredLanguage] = selectedLanguage;
     
     const response = await storeResponse(formData);
     if(response.code === 200) consentFinishedPage ();

--- a/js/pages/myToDoList.js
+++ b/js/pages/myToDoList.js
@@ -209,11 +209,15 @@ export const myToDoList = async (data, fromUserProfile, collections) => {
                     </div>
                     `
                 }
+
+                // temp disable - 061024
+                /*
                 template += `
                     <div class="alert alert-warning" id="notesOnLanguage" style="margin-top:10px;" data-i18n="mytodolist.notesOnLanguage">
                         If you'd like to take this survey in another language, simply click the button at the top of the page to switch to your preferred language before you start. Once you start this survey in one language, you'll need to finish it in that language.
                     </div>
-                `
+                `*/
+                
                 template += `
                             <ul class="nav nav-tabs" style="border-bottom:none; margin-top:20px">
                                 <li class="nav-item" style=:padding-left:10px>

--- a/js/pages/settings.js
+++ b/js/pages/settings.js
@@ -30,7 +30,9 @@ const optVars = {
     canWeVoicemailOther: null,
     loginEmail: null,
     loginPhone: null,
-    preferredLanguage: null,
+
+    // temp disable - 061024
+    // preferredLanguage: null,
 };
 
 const formVisBools = {
@@ -55,7 +57,9 @@ const optRowEles = {
     additionalEmail2Row: null,
     loginEmailRow: null,
     loginPhoneRow: null,
-    preferredLanguageRow: null,
+
+    // temp disable - 061024
+    // preferredLanguageRow: null,
 };
 
 let firebaseAuthUser;
@@ -97,7 +101,10 @@ export const renderSettingsPage = async () => {
     optVars.otherPhoneNumberComplete = userData[cId.otherPhone];
     optVars.additionalEmail1 = userData[cId.additionalEmail1];
     optVars.additionalEmail2 = userData[cId.additionalEmail2];
-    optVars.preferredLanguage = userData[cId.preferredLanguage];
+
+    // temp disable - 061024
+    // optVars.preferredLanguage = userData[cId.preferredLanguage];
+
     formVisBools.isNameFormDisplayed = false;
     formVisBools.isContactInformationFormDisplayed = false;
     formVisBools.isMailingAddressFormDisplayed = false;
@@ -296,7 +303,9 @@ const loadContactInformationElements = () => {
   optRowEles.otherPhoneVoicemailRow = document.getElementById('otherPhoneVoicemailRow');
   optRowEles.additionalEmail1Row = document.getElementById('additionalEmail1Row');
   optRowEles.additionalEmail2Row = document.getElementById('additionalEmail2Row');
-  optRowEles.preferredLanguageRow = document.getElementById('preferredLanguageRow');
+
+  // temp disable - 061024
+  // optRowEles.preferredLanguageRow = document.getElementById('preferredLanguageRow');
 
   showAndPushElementToArrayIfExists(optVars.mobilePhoneNumberComplete, optRowEles.mobilePhoneRow, !!optVars.mobilePhoneNumberComplete, contactInformationElementArray);
   showAndPushElementToArrayIfExists(optVars.canWeVoicemailMobile, optRowEles.mobilePhoneVoicemailRow, !!optVars.mobilePhoneNumberComplete, contactInformationElementArray);
@@ -307,7 +316,9 @@ const loadContactInformationElements = () => {
   showAndPushElementToArrayIfExists(optVars.canWeVoicemailOther, optRowEles.otherPhoneVoicemailRow, !!optVars.otherPhoneNumberComplete, contactInformationElementArray);
   showAndPushElementToArrayIfExists(optVars.additionalEmail1, optRowEles.additionalEmail1Row, !!optVars.additionalEmail1, contactInformationElementArray);
   showAndPushElementToArrayIfExists(optVars.additionalEmail2, optRowEles.additionalEmail2Row, !!optVars.additionalEmail2, contactInformationElementArray);
-  showAndPushElementToArrayIfExists(optVars.preferredLanguage, optRowEles.preferredLanguageRow, !!optVars.preferredLanguage, contactInformationElementArray);
+
+  // temp disable - 061024
+  // showAndPushElementToArrayIfExists(optVars.preferredLanguage, optRowEles.preferredLanguageRow, !!optVars.preferredLanguage, contactInformationElementArray);
 };
 
 const handleEditContactInformationSection = () => {
@@ -315,7 +326,11 @@ const handleEditContactInformationSection = () => {
     successMessageElement = hideSuccessMessage(successMessageElement);
     formVisBools.isContactInformationFormDisplayed = toggleElementVisibility(contactInformationElementArray, formVisBools.isContactInformationFormDisplayed);
     if (formVisBools.isContactInformationFormDisplayed) {
-      hideOptionalElementsOnShowForm([optRowEles.mobilePhoneRow, optRowEles.mobilePhoneVoicemailRow, optRowEles.mobilePhoneTextRow, optRowEles.homePhoneRow, optRowEles.homePhoneVoicemailRow, optRowEles.otherPhoneRow, optRowEles.otherPhoneVoicemailRow, optRowEles.additionalEmail1Row, optRowEles.additionalEmail2Row, optRowEles.preferredLanguageRow]);
+
+      // temp disable - 061024
+      // hideOptionalElementsOnShowForm([optRowEles.mobilePhoneRow, optRowEles.mobilePhoneVoicemailRow, optRowEles.mobilePhoneTextRow, optRowEles.homePhoneRow, optRowEles.homePhoneVoicemailRow, optRowEles.otherPhoneRow, optRowEles.otherPhoneVoicemailRow, optRowEles.additionalEmail1Row, optRowEles.additionalEmail2Row, optRowEles.preferredLanguageRow]);  
+      
+      hideOptionalElementsOnShowForm([optRowEles.mobilePhoneRow, optRowEles.mobilePhoneVoicemailRow, optRowEles.mobilePhoneTextRow, optRowEles.homePhoneRow, optRowEles.homePhoneVoicemailRow, optRowEles.otherPhoneRow, optRowEles.otherPhoneVoicemailRow, optRowEles.additionalEmail1Row, optRowEles.additionalEmail2Row]);
       toggleActiveForm(FormTypes.CONTACT);
     }
     toggleButtonText();
@@ -345,7 +360,9 @@ const handleEditContactInformationSection = () => {
     const preferredEmail = document.getElementById('newPreferredEmail').value.toLowerCase().trim();
     optVars.additionalEmail1 = document.getElementById('newadditionalEmail1').value.toLowerCase().trim();
     optVars.additionalEmail2 = document.getElementById('newadditionalEmail2').value.toLowerCase().trim();
-    optVars.preferredLanguage = document.getElementById('newpreferredLanguage').value.toLowerCase().trim();
+    
+    // temp disable - 061024
+    // optVars.preferredLanguage = document.getElementById('newpreferredLanguage').value.toLowerCase().trim();
 
     const isContactInformationValid = validateContactInformation(optVars.mobilePhoneNumberComplete, optVars.homePhoneNumberComplete, preferredEmail, optVars.otherPhoneNumberComplete, optVars.additionalEmail1, optVars.additionalEmail2);
     if (isContactInformationValid) {
@@ -357,7 +374,11 @@ const handleEditContactInformationSection = () => {
 };
 
 const submitNewContactInformation = async preferredEmail => {
-  const isSuccess = await changeContactInformation(optVars.mobilePhoneNumberComplete, optVars.homePhoneNumberComplete, optVars.canWeVoicemailMobile, optVars.canWeText, optVars.canWeVoicemailHome, preferredEmail, optVars.otherPhoneNumberComplete, optVars.canWeVoicemailOther, optVars.additionalEmail1, optVars.additionalEmail2, optVars.preferredLanguage, userData).catch(function (error) {
+
+  // temp disable - 061024  
+  // const isSuccess = await changeContactInformation(optVars.mobilePhoneNumberComplete, optVars.homePhoneNumberComplete, optVars.canWeVoicemailMobile, optVars.canWeText, optVars.canWeVoicemailHome, preferredEmail, optVars.otherPhoneNumberComplete, optVars.canWeVoicemailOther, optVars.additionalEmail1, optVars.additionalEmail2, optVars.preferredLanguage, userData).catch(function (error) {
+  
+  const isSuccess = await changeContactInformation(optVars.mobilePhoneNumberComplete, optVars.homePhoneNumberComplete, optVars.canWeVoicemailMobile, optVars.canWeText, optVars.canWeVoicemailHome, preferredEmail, optVars.otherPhoneNumberComplete, optVars.canWeVoicemailOther, optVars.additionalEmail1, optVars.additionalEmail2, userData).catch(function (error) {
     document.getElementById('changeContactInformationFail').style.display = 'block';
     document.getElementById('changeContactInformationError').innerHTML = error.message;
   });
@@ -371,7 +392,10 @@ const submitNewContactInformation = async preferredEmail => {
     handleOptionalFieldVisibility(optVars.canWeVoicemailOther, 'profileOtherVoicemailPermission', optRowEles.otherPhoneVoicemailRow, contactInformationElementArray[0], 'radio', !!optVars.otherPhoneNumberComplete);
     handleOptionalFieldVisibility(optVars.additionalEmail1, 'profileadditionalEmail1', optRowEles.additionalEmail1Row, contactInformationElementArray[0], 'text');
     handleOptionalFieldVisibility(optVars.additionalEmail2, 'profileadditionalEmail2', optRowEles.additionalEmail2Row, contactInformationElementArray[0], 'text');
-    handleOptionalFieldVisibility(optVars.preferredLanguage, 'profilepreferredLanguage', optRowEles.preferredLanguageRow, contactInformationElementArray[0], 'languageSelector');
+
+    // temp disable - 061024
+    // handleOptionalFieldVisibility(optVars.preferredLanguage, 'profilepreferredLanguage', optRowEles.preferredLanguageRow, contactInformationElementArray[0], 'languageSelector');
+
     successMessageElement = document.getElementById('changeContactInformationSuccess');
     successMessageElement.style.display = 'block';
     document.getElementById('profilePreferredEmail').textContent = preferredEmail;
@@ -1145,7 +1169,9 @@ export const renderContactInformationData = () => {
                     </b>
                 </span>
             </div>
-        </div>         
+        </div>  
+        
+        <!-- temp disable - 061024
         <div class="row userProfileLinePaddings" id="preferredLanguageRow" style="display:none">
             <div class="col">
                 <span class="userProfileBodyFonts">
@@ -1160,7 +1186,8 @@ export const renderContactInformationData = () => {
                     </b>
                 </span>
             </div>
-        </div>         
+        </div>  
+        -->       
       `);
 };
 
@@ -1284,6 +1311,7 @@ export const renderChangeContactInformationGroup = () => {
                       </div>
                   </div>
 
+                  <!-- temp disable - 061024
                   <div class="form-group row">
                       <div class="col">
                           <label for="newpreferredLanguage" class="custom-form-label" data-i18n="languageSelector.title">Additional Email 2 (optional)</label>
@@ -1294,6 +1322,7 @@ export const renderChangeContactInformationGroup = () => {
                           </select>
                       </div>
                   </div>
+                  -->
   
                   <div class="form-group row">
                       <div class="col">

--- a/js/settingsHelpers.js
+++ b/js/settingsHelpers.js
@@ -404,7 +404,10 @@ export const changeName = async (firstName, lastName, middleName, suffix, prefer
   return isSuccess;
 };
 
-export const changeContactInformation = async (mobilePhoneNumberComplete, homePhoneNumberComplete, canWeVoicemailMobile, canWeText, canWeVoicemailHome, preferredEmail, otherPhoneNumberComplete, canWeVoicemailOther, additionalEmail1, additionalEmail2, preferredLanguage, userData) => {
+// temp disable - 061024
+// export const changeContactInformation = async (mobilePhoneNumberComplete, homePhoneNumberComplete, canWeVoicemailMobile, canWeText, canWeVoicemailHome, preferredEmail, otherPhoneNumberComplete, canWeVoicemailOther, additionalEmail1, additionalEmail2, preferredLanguage, userData) => {
+
+  export const changeContactInformation = async (mobilePhoneNumberComplete, homePhoneNumberComplete, canWeVoicemailMobile, canWeText, canWeVoicemailHome, preferredEmail, otherPhoneNumberComplete, canWeVoicemailOther, additionalEmail1, additionalEmail2, userData) => {
   document.getElementById('changeContactInformationFail').style.display = 'none';
   document.getElementById('changeContactInformationGroup').style.display = 'none';
 
@@ -430,7 +433,8 @@ export const changeContactInformation = async (mobilePhoneNumberComplete, homePh
     [cId.canWeVoicemailOther]: parseInt(canWeVoicemailOther),
     [cId.additionalEmail1]: additionalEmail1,
     [cId.additionalEmail2]: additionalEmail2,
-    [cId.preferredLanguage]: parseInt(preferredLanguage)
+    // temp disable - 061024
+    // [cId.preferredLanguage]: parseInt(preferredLanguage)
   };
 
   let { changedUserDataForProfile, changedUserDataForHistory } = findChangedUserDataValues(newValues, userData, 'changeContactInformation');


### PR DESCRIPTION
This PR addresses the following Issue:
* N/A
-----
## Background Details
* Spanish release has been pushed out a month, need to temporarily disable some code to minimize impact to PWA without having to revert all commits
-----
## Technical Changes
* `app.js`
  * always setting language in `app state` to English
  * disabling initialization of `languageSelectorContainer` and calls to `addEventLanguageSelector()`

* `consent.js`
  * disabling updating participant document with `preferredLanguage` selection

* `myToDoList.js`
  * disabling message suggesting option to switch survey languages

* `settings.js`
  * removing initialization and references to all variables relating to preferred language

* `settingsHelpers.js`
  * removed references to preferred language in `changeContactInformation()` 