### PR TITLE
update quest fallback version

### DIFF
--- a/js/pages/questionnaire.js
+++ b/js/pages/questionnaire.js
@@ -28,11 +28,12 @@ async function loadQuestConfig() {
             ...(data?.['Connect_ID'] && { connectID: data['Connect_ID'] }),
         });
 
+        // TODO: Quest 2.0 manage version with Firestore or similar
         questConfig = {
-            "myconnect.cancer.gov": "https://cdn.jsdelivr.net/gh/episphere/quest@v1.1.4/replace2.js",
-            "myconnect-stage.cancer.gov": "https://cdn.jsdelivr.net/gh/episphere/quest@v1.1.4/replace2.js",
+            "myconnect.cancer.gov": "https://cdn.jsdelivr.net/gh/episphere/quest@v1.1.6/replace2.js",
+            "myconnect-stage.cancer.gov": "https://cdn.jsdelivr.net/gh/episphere/quest@v1.1.6/replace2.js",
             "episphere.github.io": "https://episphere.github.io/quest/replace2.js",
-            "localhost:5000": "https://cdn.jsdelivr.net/gh/episphere/quest@v1.1.4/replace2.js"
+            "localhost:5000": "https://cdn.jsdelivr.net/gh/episphere/quest@v1.1.6/replace2.js"
         }
     }
 }


### PR DESCRIPTION
update Quest error handling fallback to most recent version v1.1.6
Quest releases: https://github.com/episphere/quest/releases