### PR TITLE
Soccer Updates

### DIFF
--- a/js/pages/questionnaire.js
+++ b/js/pages/questionnaire.js
@@ -270,7 +270,7 @@ function externalListeners(language){
                 task3 = e.target[1].value;
                 const soccerResults = await buildSoccerResults(title3, task3, language);
     
-                await buildHTML(soccerResults, occuptn1);
+                buildHTML(soccerResults, occuptn1);
             });
         }
         else {
@@ -280,7 +280,7 @@ function externalListeners(language){
                 title3 = e.target[0].value;
                 const soccerResults = await buildSoccerResults(title3, '', language);
     
-                await buildHTML(soccerResults, occuptn1);
+                buildHTML(soccerResults, occuptn1);
             });
         }
     }

--- a/js/pages/questionnaire.js
+++ b/js/pages/questionnaire.js
@@ -277,7 +277,7 @@ function externalListeners(language){
             work3.addEventListener("submit", async (e) => {
                 e.preventDefault();
                 
-                title3 = e.target[0].value;
+                title3 = e.target[1].value;
                 const soccerResults = await buildSoccerResults(title3, '', language);
     
                 buildHTML(soccerResults, occuptn1);
@@ -290,13 +290,13 @@ function externalListeners(language){
             work7.addEventListener("submit", (e) => {
                 e.preventDefault();
                 
-                title7 = e.target[0].value;
+                title7 = e.target[1].value;
             });
 
             work7b.addEventListener("submit", async (e) => {
                 e.preventDefault();
     
-                task7 = e.target[0].value;
+                task7 = e.target[1].value;
                 const soccerResults = await buildSoccerResults(title7, task7, language);
     
                 buildHTML(soccerResults, occuptn2);
@@ -306,7 +306,7 @@ function externalListeners(language){
             work7.addEventListener("submit", async (e) => {
                 e.preventDefault();
                 
-                title7 = e.target[0].value;
+                title7 = e.target[1].value;
                 const soccerResults = await buildSoccerResults(title7, '', language);
     
                 buildHTML(soccerResults, occuptn2);

--- a/js/pages/ssn.js
+++ b/js/pages/ssn.js
@@ -1,4 +1,4 @@
-import { storeSocial, storeResponse, hideAnimation, translateHTML, getSelectedLanguage } from '../shared.js';
+import { storeSocial, storeResponse, hideAnimation, translateHTML } from '../shared.js';
 import fieldMapping from '../fieldToConceptIdMapping.js';
 
 const hardErrorNineFormat = '<span data-i18n="ssn.hardErrorNineFormat">Please enter a valid Social Security Number in this format: 999-99-9999.</span>';

--- a/js/pages/ssn.js
+++ b/js/pages/ssn.js
@@ -17,8 +17,6 @@ let ssnFourDigitsShow;
 let ssnFourDigitsConfirm;
 let ssnFourDigitsConfirmShow;
 
-let language;
-
 let ignoreBlur = false;
 
 export const socialSecurityTemplate = (data) => {
@@ -33,8 +31,6 @@ export const socialSecurityTemplate = (data) => {
         
         storeResponse(formData);
     }
-
-    language = getSelectedLanguage();
 
     window.scrollTo(0, 0);
 
@@ -385,7 +381,6 @@ const endMessageOne = () => {
     document.getElementById('endMessageOneNext').addEventListener('click', async () => {
         
         const formData = ssnNineDigits ? { ssnNineDigits } : { ssnFourDigits };
-        formData[fieldMapping.surveyLanguage] = language;
 
         await storeSocial(formData);
         location.reload();

--- a/js/pages/ssn.js
+++ b/js/pages/ssn.js
@@ -1,4 +1,4 @@
-import { storeSocial, storeResponse, hideAnimation, translateHTML } from '../shared.js';
+import { storeSocial, storeResponse, hideAnimation, translateHTML, getSelectedLanguage } from '../shared.js';
 import fieldMapping from '../fieldToConceptIdMapping.js';
 
 const hardErrorNineFormat = '<span data-i18n="ssn.hardErrorNineFormat">Please enter a valid Social Security Number in this format: 999-99-9999.</span>';
@@ -17,6 +17,8 @@ let ssnFourDigitsShow;
 let ssnFourDigitsConfirm;
 let ssnFourDigitsConfirmShow;
 
+let language;
+
 let ignoreBlur = false;
 
 export const socialSecurityTemplate = (data) => {
@@ -31,6 +33,8 @@ export const socialSecurityTemplate = (data) => {
         
         storeResponse(formData);
     }
+
+    language = getSelectedLanguage();
 
     window.scrollTo(0, 0);
 
@@ -381,6 +385,7 @@ const endMessageOne = () => {
     document.getElementById('endMessageOneNext').addEventListener('click', async () => {
         
         const formData = ssnNineDigits ? { ssnNineDigits } : { ssnFourDigits };
+        formData[fieldMapping.surveyLanguage] = language;
 
         await storeSocial(formData);
         location.reload();

--- a/js/shared.js
+++ b/js/shared.js
@@ -1799,7 +1799,7 @@ export const updateStartSurveyParticipantData = async (sha, url, moduleId, repai
 
         questData[fieldMapping[moduleId].conceptId + ".sha"] = sha;
         questData[fieldMapping[moduleId].conceptId + "." + fieldMapping[moduleId].version] = version;
-        questData[fieldMapping[moduleId].conceptId + "." + fieldMapping.surveyLanguage] = appState.getState().language;
+        questData[fieldMapping[moduleId].conceptId + "." + fieldMapping.surveyLanguage] = getSelectedLanguage();
 
         // Do not update startTs if the sha is being repaired. Retain the original startTs, which coincides with the fetched survey.
         if (!repairShaValue) formData[fieldMapping[moduleId].startTs] = new Date().toISOString();


### PR DESCRIPTION
This PR addresses the following Issue:
* https://github.com/episphere/connect/issues/917
-----
## Background Details
* Module 1 needs to return SOCcer results in the correct language for WORK3 / WORK7 questions
-----
## Technical Changes
* Added `language` parameter when passing in `externalListeners()` to Quest
* Updated index of `target` we are grabbing value from since elements are wrapped with `fieldset` now
* `buildSoccerResults()` now calls external GCP Cloud Function to handle getting SOCcer results given title, task, and language
* Updated `updateStartSurveyParticipantData()` to call `getSelectedLanguage()` instead of accessing `appState` directly