### PR TITLE
MCS Bug Fix

### DIFF
--- a/js/pages/questionnaire.js
+++ b/js/pages/questionnaire.js
@@ -146,12 +146,6 @@ async function startModule(data, modules, moduleId, questDiv) {
             throw new Error('Error: No path found for module (null key).');
         }
 
-        if (modules[fieldMapping[moduleId].conceptId]?.['treeJSON']) {
-            tJSON = modules[fieldMapping[moduleId].conceptId]['treeJSON'];
-        } else {
-            await localforage.clear();
-        }
-
         // Module has not been started.
         if (data[fieldMapping[moduleId].statusFlag] === fieldMapping.moduleStatus.notStarted) {
             
@@ -173,6 +167,7 @@ async function startModule(data, modules, moduleId, questDiv) {
         // Module has been started and has a SHA value. Note: Don't need to update participant for this case since record exists. Fetch module text directly.
         } else if (modules[fieldMapping[moduleId].conceptId]?.['sha']) {
 
+            tJSON = await getTree(modules, moduleId);
             ({ path, lang } = getMarkdownPath(modules[fieldMapping[moduleId].conceptId][fieldMapping.surveyLanguage], moduleConfig[key]));
 
             sha = modules[fieldMapping[moduleId].conceptId]['sha'];
@@ -190,6 +185,7 @@ async function startModule(data, modules, moduleId, questDiv) {
             console.error('Module started but SHA not found. Fixing the SHA not found case.');
             const startSurveyTimestamp = data[fieldMapping[moduleId].startTs] || '';
 
+            tJSON = await getTree(modules, moduleId);
             ({ path, lang } = getMarkdownPath(modules[fieldMapping[moduleId].conceptId][fieldMapping.surveyLanguage], moduleConfig[key]));
 
             // Get the SHA from the GitHub API. The correct SHA is the SHA for the active survey commit when the participant started the survey.
@@ -645,4 +641,13 @@ const getMarkdownPath = (value, config) => {
     }
 
     return { path, lang };
+}
+
+const getTree = async (modules, moduleId) => {
+
+    if (modules[fieldMapping[moduleId].conceptId]?.['treeJSON']) {
+        return modules[fieldMapping[moduleId].conceptId]['treeJSON'];
+    } else {
+        await localforage.clear();
+    }
 }

--- a/js/pages/questionnaire.js
+++ b/js/pages/questionnaire.js
@@ -136,6 +136,8 @@ async function startModule(data, modules, moduleId, questDiv) {
     let lang;
     let moduleText;
 
+    await localforage.clear();
+
     try {
         inputData = setInputData(data, modules); 
         moduleConfig = questionnaireModules();
@@ -645,9 +647,5 @@ const getMarkdownPath = (value, config) => {
 
 const getTree = async (modules, moduleId) => {
 
-    if (modules[fieldMapping[moduleId].conceptId]?.['treeJSON']) {
-        return modules[fieldMapping[moduleId].conceptId]['treeJSON'];
-    } else {
-        await localforage.clear();
-    }
+    return modules[fieldMapping[moduleId].conceptId]?.['treeJSON'];
 }


### PR DESCRIPTION
This PR addresses the following Issue:
* N/A
-----
## Background Details
* Quest Tree is persisting in survey Firestore document after "resetting" of Menstrual Cycle Survey due to race conditions of storing the tree from Quest after nullifying fields from PWA
* If someone is starting a survey, we shouldn't even be trying to find a tree to pass into Quest
-----
## Technical Changes
* Created function `getTree()` for fetching `treeJSON` object from module document
* Only calling function for scenarios where a survey has been started already