### PR TITLE
Quest Reload

### DIFF
--- a/js/shared.js
+++ b/js/shared.js
@@ -246,7 +246,7 @@ const completeSurvey = async (data, moduleId) => {
 
     await storeResponse(formData);
 
-    // location.reload(); commenting out temporarily 
+    location.reload();
 }
 
 export const storeResponse = async (formData) => {


### PR DESCRIPTION
This PR addresses the following Issue:
* https://github.com/episphere/connect/issues/759
-----
## Background Details
* Quest shouldn't be trying to reload the form when we submit, it should be handled by whatever is calling Quest if that functionality is needed.
* Re-Implementation of https://github.com/episphere/connectApp/pull/654
-----
## Technical Changes
* added `location.reload()` call at the end of `completeSurvey()` function