### PR TITLE
null handle 250235523, rm console.logs

### DIFF
--- a/js/pages/settings.js
+++ b/js/pages/settings.js
@@ -224,7 +224,7 @@ const showMajorFormDivs = () => {
   document.getElementById('contactInformationDiv').style.display = 'block';
   document.getElementById('mailingAddressDiv').style.display = 'block';
   document.getElementById('signInInformationDiv').style.display = 'block';
-  if (userData[cId.isPOBox].toString() === cId.yes.toString()) {
+  if (userData[cId.isPOBox]?.toString() === cId.yes.toString()) {
     const addrDiv = document.getElementById("physicalMailingAddressDiv");
     if(addrDiv) addrDiv.style.display = "block";
   }

--- a/js/shared.js
+++ b/js/shared.js
@@ -1212,10 +1212,6 @@ export const inactivityTime = () => {
         const lastActivity = parseInt(localStorage.getItem(activityKey), 10) || Date.now();
         const now = Date.now();
 
-        console.log("lastActivity", lastActivity);
-        console.log('TIME ELAPSED', now - lastActivity);
-        console.log('SHOW MODAL', now - lastActivity > inactivityTimeout);
-
         const isWarningShownGlobally = localStorage.getItem(warningKey) === 'true';
 
         // Only show warning if none is currently shown globally (for management with multiple tabs open)


### PR DESCRIPTION
Small fixes found in testing:
•Null handle 250235523. This will be active in a future release, but is currently null for all stage and prod participants.
•rm leftover console.logs from inactivity timer testing.