### PR TITLE
Bug Fix

### DIFF
--- a/i18n/en.js
+++ b/i18n/en.js
@@ -1848,7 +1848,7 @@ const en = {
         "mod2024ConnectExperienceSurvey": "2024 Connect Experience Survey",
         "modCancerScreeningHistorySurvey": "Cancer Screening History Survey",
         "modDietHistoryQuestionnaireIIIDHQIII": "Diet History Questionnaire III (DHQ III)",
-        "modROIPreference2025": "2025 Return of Results Preference Survey",
+        "mod2025ReturnofResultsPreferenceSurvey": "2025 Return of Results Preference Survey",
         "sessionInactiveTitle": "Inactive",
         "sessionInactive": "You were inactive for 20 minutes, would you like to extend your session?<div class=\"modal-footer\"><button type=\"button\" title=\"Close\" class=\"btn btn-dark log-out-user\" data-bs-dismiss=\"modal\">Log Out</button><button type=\"button\" title=\"Continue\" class=\"btn btn-primary extend-user-session\" data-bs-dismiss=\"modal\">Continue</button></div>",
         "homeTitle": "My Connect - Home",

--- a/i18n/es.js
+++ b/i18n/es.js
@@ -1851,7 +1851,7 @@
         "mod2024ConnectExperienceSurvey": "2024 Encuesta Sobre Experiencia de Connect",
         "modCancerScreeningHistorySurvey": "Encuesta sobre historial de exámenes de detección de cáncer",
         "modDietHistoryQuestionnaireIIIDHQIII": "Cuestionario de Historial Alimentación III (DHQ III, por sus siglas en ingles)",
-        "modROIPreference2025": "Encuesta de Preferencias para la Devolución de Resultados 2025",
+        "mod2025ReturnofResultsPreferenceSurvey": "Encuesta de Preferencias para la Devolución de Resultados 2025",
         "sessionInactiveTitle": "Inactivo",
         "sessionInactive": "Ha estado inactivo durante 20 minutos, ¿desea extender la sesión?<div class=\"modal-footer\"><button type=\"button\" title=\"Cerrar\" class=\"btn btn-dark log-out-user\" data-bs-dismiss=\"modal\">Cerrar sesión</button><button type=\"button\" title=\"Continuar\" class=\"btn btn-primary extend-user-session\" data-bs-dismiss=\"modal\">Continuar</button></div>",
         "homeTitle": "My Connect - Inicio",


### PR DESCRIPTION
Parent Issue: https://github.com/episphere/connect/issues/1246

This pull request updates the English and Spanish translation files to correct the translation key for the 2025 Return of Results Preference Survey, ensuring consistency across both languages.

Translation key updates:

* Updated the translation key from `modROIPreference2025` to `mod2025ReturnofResultsPreferenceSurvey` in both `i18n/en.js` and `i18n/es.js` to match the naming convention used for other survey modules. [[1]](diffhunk://#diff-26f27b4b544fa54e757f8d84d780914b56677cdca1e687215d7b964fa885bb38L1851-R1851) [[2]](diffhunk://#diff-61af1232127b3c0f7ff881945bc118ee171e1cd54fb3a8084c1c268377efd963L1854-R1854)