### PR TITLE
1304 Bug Fix

### DIFF
--- a/js/settingsHelpers.js
+++ b/js/settingsHelpers.js
@@ -991,7 +991,7 @@ export const changeMailingAddress = async (id, addressLine1, addressLine2, city,
       [cId.altCity]: isClearing ? null : city,
       [cId.altState]: isClearing ? null : state,
       [cId.altZip]: isClearing ? null : (zip ? zip.toString() : ""),
-      [cId.isPOBoxAltAddress]: isClearing ? cId.no : (isPOBox ? cId.yes : cId.no)
+      [cId.isPOBoxAltAddress]: isClearing ? null : (isPOBox ? cId.yes : cId.no)
      };
   }
 


### PR DESCRIPTION
Parent Issue: https://github.com/episphere/connect/issues/1304

This pull request makes a minor adjustment to how the alternate address PO Box status is handled in the `changeMailingAddress` helper function. Specifically, it changes the value assigned when clearing the address, setting it to `null` instead of a default "no" value. This ensures consistency with how other address fields are cleared.