### PR TITLE
Addressed feedback on 1344

### DIFF
--- a/i18n/en.js
+++ b/i18n/en.js
@@ -883,7 +883,7 @@ const en = {
             "updateMailingAddressLink": "update your mailing address",
             "cannotShipToPOBoxesSecondHalf": " or click the button below to add a new physical address where we should ship your kit.",
             "updateMyPhysicalAddress": "Update my physical address.",
-            "updateMyMailingAddress": "Update my mailing address.",
+            "updateMyMailingAddress": "Update my mailing address",
             "cannotShipToPOBoxesNote": "Note: we can't ship kits to P.O. Boxes or international addresses.",
             "selectKitType": "Select your kit type:",
             "chooseKitGhostValue": "Choose the kit you are requesting",

--- a/i18n/es.js
+++ b/i18n/es.js
@@ -887,7 +887,7 @@
             "updateMailingAddressLink": "Ponga al día su dirección postal",
             "cannotShipToPOBoxesSecondHalf": " o haga clic en el botón de abajo para agregar un nuevo domicilio al cual podamos enviarle su kit.",
             "updateMyPhysicalAddress": "Cambiar mi domicilio.",
-            "updateMyMailingAddress": "Cambiar mi dirección postal.",
+            "updateMyMailingAddress": "Cambiar mi dirección postal",
             "cannotShipToPOBoxesNote": "Nota: No podemos enviar kits a apartados postales o direcciones internacionales..",
             "selectKitType": "Elija su tipo de kit:",
             "chooseKitGhostValue": "Elija el kit que solicita",

--- a/js/pages/samples.js
+++ b/js/pages/samples.js
@@ -784,7 +784,7 @@ const renderParticipantPhysicalAddress = (participant, displayCurrentPhysicalAdd
         + `<div class="row"><div class="col-1"></div><div class="col-11">${formattedAddress}</div></div>` + newInnerHTML;
     }
 
-    requestAKitInner.innerHTML = newInnerHTML;
+    requestAKitInner.innerHTML = translateHTML(newInnerHTML);
     toggleElementVisibility([document.getElementById(`currentMailingAddressDiv2`), document.getElementById(`changeMailingAddressGroup2`)], false);
     addEventAddressAutoComplete(2);
     
@@ -837,9 +837,11 @@ const renderParticipantMailingAddress = (participant) => {
             ${addressObj.address_2 ? `${addressObj.address_2}<br />` : ''}
         ${addressObj.city || ''}${addressObj.state ? ',':''} ${addressObj.state || ''} ${addressObj.zip_code || ''}`;
 
-    requestAKitInner.innerHTML = '<div class="messagesSubHeader" data-i18n="samples.requestAKit.currentMailingAddress">Current Mailing Address</div>' 
+    const newInnerHTML = '<div class="messagesSubHeader" data-i18n="samples.requestAKit.currentMailingAddress">Current Mailing Address</div>' 
         + `<div class="row"><div class="col-1"></div><div class="col-11">${formattedAddress}</div></div><div class="messagesSubHeader" data-i18n="samples.requestAKit.newMailingAddress">New Mailing Address</div>` 
         + renderChangeMailingAddressGroup(1, true);
+
+    requestAKitInner.innerHTML = translateHTML(newInnerHTML);
     toggleElementVisibility([document.getElementById(`currentMailingAddressDiv1`), document.getElementById(`changeMailingAddressGroup1`)], false);
     addEventAddressAutoComplete(1);
     


### PR DESCRIPTION
* Removed stray period from an "Update my mailing address" message location in English and Spanish
* Fixed an issue where some text when adding and updating physical and mailing addresses was not translating.