### PR TITLE
Added a check for noreply emails

### DIFF
--- a/js/pages/dashboard.js
+++ b/js/pages/dashboard.js
@@ -237,7 +237,7 @@ export const renderDashboard = async (data, fromUserProfile, collections) => {
                     (data[fieldMapping.revokeHipaa] !== fieldMapping.yes  && data[fieldMapping.consentWithdrawn] !== fieldMapping.yes) && 
                     !isParticipantDataDestroyed(data) &&
                     !data['secondaryDismissed'] && 
-                    (!data[fieldMapping.firebaseAuthEmail] || !data[fieldMapping.firebaseAuthPhone]))
+                    (!data[fieldMapping.firebaseAuthEmail] || (userData[cId.firebaseAuthEmail] && userData[cId.firebaseAuthEmail].startsWith('noreply')) || !data[fieldMapping.firebaseAuthPhone]))
                 {
                     showSecondaryLoginModal();
                 }


### PR DESCRIPTION
An email login field that starts with noreply should be treated as empty for the purposes of determining whether the secondary login modal is displayed.  I have updated the check to reflect that