### PR TITLE
1630 Fix

### DIFF
--- a/js/settingsHelpers.js
+++ b/js/settingsHelpers.js
@@ -854,7 +854,7 @@ export const validateAltContactInformation = async (altContactMobilePhoneComplet
     hasError = true;
   }
 
-  if (!altContactEmail || !validEmailFormat.test(altContactEmail)) {
+  if (altContactEmail && !validEmailFormat.test(altContactEmail)) {
     errorMessage('newAltContactEmail', '<span data-i18n="settingsHelpers.emailFormat">'+translateText('settingsHelpers.emailFormat')+'</span>', focus);
     focus = false;
     hasError = true;
@@ -871,7 +871,7 @@ export const validateAltContactInformation = async (altContactMobilePhoneComplet
       }
   }
 
-  if (!hasError) {
+  if (!hasError && altContactEmail) {
     const emailValidation = await emailAddressValidation({
       emails: {
         altContactEmail: altContactEmail,


### PR DESCRIPTION
For [1630](https://github.com/episphere/connect/issues/1630).

Editing the user profile's alternate contact section no longer requires an alternate email address to be entered.