### PR TITLE
1622 Follow-up

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -972,6 +972,17 @@ input:checked + .slider:before {
 consentNextButton:hover{
     background-color: #f9a921 !important;
 }
+#continueBtn.btn-primary{
+    background-color:#FFBF17 !important;
+    border-color:#FFBF17 !important;
+    font-weight:bold !important;
+    color: #2E2E2E !important;
+    padding: 6px 12px !important;
+}
+#continueBtn.btn-primary:hover{
+    background-color: #f9a921 !important;
+}
+
 .userProfileHeader{
     font-size:28px;
     font-family: 'Montserrat', sans-serif;

--- a/i18n/es.js
+++ b/i18n/es.js
@@ -1340,7 +1340,7 @@
         "old": "Anteriores",
         "noNotifications": "¡No se encontró ninguna notificación!",
         "invalidAddressDescription": "La dirección que ingresó quizá no sea válida. Por favor compruebe lo que ingresó abajo. Si la dirección no es correcta, haga clic en 'Regresar' y corrija la dirección. Si la dirección es correcta, haga clic en 'Continuar con la dirección'. Solo podemos enviar comunicaciones y paquetes de Connect a direcciones validas.",
-        "continueWithAddress": "Continuar con la Dirección",
+        "continueWithAddress": "Continuar con la dirección",
         "invalidAddressFooter": "Si está teniendo problemas arreglando estos errores y no puede entregar su perfil, por favor póngase en contacto en el <a href=\"https://myconnect.cancer.gov/support\" target=\"_blank\">Centro de Asistencia de Connect</a> para ayuda." 
     },
     "settingsHelpers": {

--- a/js/event.js
+++ b/js/event.js
@@ -1449,7 +1449,7 @@ const showInvalidAddressWarning = (uspsSuggestion, formData, type) => {
     document.getElementById('connectModalFooter').innerHTML = translateHTML(`
         <div class="d-flex justify-content-between w-100">
             <button data-i18n="event.navButtonsClose" type="button" title="Go Back" class="btn btn-dark" data-bs-dismiss="modal">Go Back</button>
-            <button  data-i18n="event.continueWithAddress"  id="continueBtn" class="btn btn-dark" >Continue with Address</a>
+            <button  data-i18n="event.continueWithAddress"  id="continueBtn" class="btn btn-primary" >Continue with Address</a>
         </div>
         <p style="margin-top: 20px; font-size: 12px" data-i18n="event.invalidAddressFooter">
             If you are having problems fixing these errors and can’t submit your profile, please reach out to the <a href="https://myconnect.cancer.gov/support" target="_blank">Connect Support Center</a> for help.


### PR DESCRIPTION
Styling changes requested in follow-up on 1622.

* "Continue with Address" button now in yellow
* Capitalization for Spanish variant of "Continue with Address" button changed to reflect capitalization conventions used for other Spanish text in app.