### PR TITLE
HOTFIX

### DIFF
--- a/app.js
+++ b/app.js
@@ -169,7 +169,7 @@ window.onload = async () => {
             const idToken = await user.getIdToken();
             appState.set({ idToken });
             if (!user.isAnonymous) {
-                localforage.clear();
+                if (typeof localforage !== 'undefined') localforage.clear();
                 const firstSignInTime = new Date(user.metadata.creationTime).toISOString();
                 appState.setState({ participantData: { firstSignInTime } });
 
@@ -530,7 +530,7 @@ export const signOut = async () => {
         window.DD_RUM.stopSession();
         isDataDogUserSessionSet = false;
     }
-    localforage.clear();
+    if (typeof localforage !== 'undefined') localforage.clear();
 
     await firebase.auth().signOut();
 

--- a/js/pages/questionnaire.js
+++ b/js/pages/questionnaire.js
@@ -172,7 +172,7 @@ async function startModule(moduleId) {
     let lang;                                                               // The participant's preferred language.
     let moduleText;                                                         // The fetched module's markdown text.
 
-    await localforage.clear();
+    if (typeof localforage !== 'undefined') await localforage.clear();
     
     try {
         inputData = setInputData(participantData, modules); 


### PR DESCRIPTION
CSC Ticket Number: CS0085653

This pull request introduces small but important safety checks to prevent errors when clearing local storage using `localforage`. The main change ensures that `localforage` is only accessed if it is defined, which helps avoid runtime errors in environments where `localforage` may not be available.

Most important changes:

**Robustness improvements for local storage operations:**

* Added checks for `typeof localforage !== 'undefined'` before calling `localforage.clear()` in `app.js` (within `window.onload` and `signOut`) and in `js/pages/questionnaire.js` (within `startModule`) to prevent errors if `localforage` is not loaded or available. [[1]](diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fL172-R172) [[2]](diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fL533-R533) [[3]](diffhunk://#diff-6cc90e5651ecec2d19b608e358461f268b550da8cfc7ed9362cbae6005dd8e1aL175-R175)