### PR TITLE
Bug Fix - Empty Strings in Country

### DIFF
--- a/js/pages/samples.js
+++ b/js/pages/samples.js
@@ -473,7 +473,7 @@ const submitNewMailingAddress = async (id, addressLine1, addressLine2, city, sta
     const userData = data.data;
     const isInternational = conceptId.no; // no international addresses here (kit shipments are for domestic, non-PO Box addresses only)
     const addressLine3 = '';
-    const country = '';
+    const country = null;
     const isSuccess = await changeMailingAddress(id, addressLine1, addressLine2, city, state, zip, userData, isInternational, addressLine3, country, isPOBox, false, isValidatedByUSPS).catch(function (error) {
         console.error('Error', error);
         document.getElementById(`mailingAddressFail${id}`).style.display = 'block';

--- a/js/settingsHelpers.js
+++ b/js/settingsHelpers.js
@@ -976,7 +976,7 @@ export const changeMailingAddress = async (id, addressLine1, addressLine2, city,
       [cId.isPOBox]: isPOBox ? cId.yes : cId.no,
       [cId.isIntlAddr]: isInternational ?? cId.no,
       [cId.address3]: addressLine3 && isInternational === cId.yes ? addressLine3 : '', 
-      [cId.country]: country && isInternational === cId.yes ? parseInt(country, 10) || '' : '',
+      [cId.country]: country && isInternational === cId.yes ? parseInt(country, 10) || null : null,
       [cId.isMailingAddressUSPSUnvalidated]: getUSPSUnvalidatedValue(isValidatedByUSPS, cId.yes, cId.no),
     };
   } else if (id === 2) {
@@ -989,7 +989,7 @@ export const changeMailingAddress = async (id, addressLine1, addressLine2, city,
       [cId.physicalZip]: isClearing ? null : (zip ? zip.toString() : ""),
       [cId.physicalAddrIntl]: isClearing ? null : isInternational,
       [cId.physicalAddress3]: isClearing ? null : (addressLine3 && isInternational === cId.yes ? addressLine3 : ''), 
-      [cId.physicalCountry]: isClearing ? null : (country && isInternational === cId.yes ? parseInt(country, 10) || '' : ''), 
+      [cId.physicalCountry]: isClearing ? null : (country && isInternational === cId.yes ? parseInt(country, 10) || null : null), 
       [cId.isPhysicalAddressUSPSUnvalidated]: isClearing ? null : getUSPSUnvalidatedValue(isValidatedByUSPS, cId.yes, cId.no),
     };
   } else if (id === 3) {
@@ -1008,7 +1008,7 @@ export const changeMailingAddress = async (id, addressLine1, addressLine2, city,
       [cId.isPOBoxAltAddress]: isAltClearing ? null : (isPOBox ? cId.yes : cId.no),
       [cId.isIntlAltAddress]: isAltClearing ? null : isInternational,
       [cId.altAddress3]: isAltClearing ? null : (addressLine3 && isInternational === cId.yes ? addressLine3 : ''), 
-      [cId.altCountry]: isAltClearing ? null : (country && isInternational === cId.yes ? parseInt(country, 10) || '' : ''), 
+      [cId.altCountry]: isAltClearing ? null : (country && isInternational === cId.yes ? parseInt(country, 10) || null : null), 
       [cId.isAltAddressUSPSUnvalidated]: isAltClearing ? null : getUSPSUnvalidatedValue(isValidatedByUSPS, cId.yes, cId.no),
      };
   }

--- a/tests/settingsHelpers.spec.js
+++ b/tests/settingsHelpers.spec.js
@@ -607,4 +607,109 @@ describe('settingsHelpers', () => {
     expect(settingsSharedMocks.showAnimation).toHaveBeenCalledTimes(1);
     expect(settingsSharedMocks.hideAnimation).toHaveBeenCalledTimes(1);
   });
+
+  describe('changeMailingAddress country fields', () => {
+    const buildAddressDom = (id) => {
+      const elements = {};
+      elements[`mailingAddressFail${id}`] = { style: { display: 'block' } };
+      elements[`changeMailingAddressGroup${id}`] = { style: { display: 'block' } };
+      elements[`mailingAddressError${id}`] = { textContent: '' };
+      elements['mailingAddressFail'] = { style: { display: 'none' } };
+      elements['mailingAddressError'] = { innerHTML: '' };
+      return elements;
+    };
+
+    const buildAddressUserData = (overrides = {}) => ({
+      [cId.userProfileHistory]: [],
+      [cId.prefEmail]: 'test@example.com',
+      [cId.address1]: '123 Main St',
+      [cId.city]: 'Denver',
+      [cId.state]: 'CO',
+      [cId.zip]: '80202',
+      [cId.country]: '',
+      [cId.isIntlAddr]: cId.no,
+      ...overrides,
+    });
+
+    it('sets country to null (not empty string) for domestic mailing address (id=1)', async () => {
+      installDocumentByIdMap(buildAddressDom(1));
+
+      const userData = buildAddressUserData();
+      await settingsHelpers.changeMailingAddress(1, '456 Oak Ave', '', 'Boulder', 'CO', '80301', userData, cId.no, '', null, false);
+
+      const storeCall = settingsSharedMocks.storeResponse.mock.calls[0]?.[0];
+      expect(storeCall).toBeDefined();
+      expect(storeCall[cId.country]).toBeNull();
+      expect(storeCall[cId.country]).not.toBe('');
+    });
+
+    it('sets country to parsed integer for international mailing address (id=1)', async () => {
+      installDocumentByIdMap(buildAddressDom(1));
+
+      const userData = buildAddressUserData({ [cId.isIntlAddr]: cId.yes, [cId.country]: 999 });
+      await settingsHelpers.changeMailingAddress(1, '456 Oak Ave', '', 'London', 'ENG', 'SW1A', userData, cId.yes, 'Line 3', '123', false);
+
+      const storeCall = settingsSharedMocks.storeResponse.mock.calls[0]?.[0];
+      expect(storeCall).toBeDefined();
+      expect(storeCall[cId.country]).toBe(123);
+    });
+
+    it('sets country to null when parseInt fails on non-numeric country value for international address', async () => {
+      installDocumentByIdMap(buildAddressDom(1));
+
+      const userData = buildAddressUserData({ [cId.isIntlAddr]: cId.yes });
+      await settingsHelpers.changeMailingAddress(1, '456 Oak Ave', '', 'London', 'ENG', 'SW1A', userData, cId.yes, 'Line 3', 'InvalidCountry', false);
+
+      const storeCall = settingsSharedMocks.storeResponse.mock.calls[0]?.[0];
+      expect(storeCall).toBeDefined();
+      expect(storeCall[cId.country]).toBeNull();
+      expect(storeCall[cId.country]).not.toBe('');
+    });
+
+    it('sets physicalCountry to null for domestic physical address (id=2)', async () => {
+      installDocumentByIdMap(buildAddressDom(2));
+
+      const userData = buildAddressUserData({ [cId.physicalAddress1]: '789 Pine', [cId.physicalCountry]: '' });
+      await settingsHelpers.changeMailingAddress(2, '101 Elm St', '', 'Aurora', 'CO', '80010', userData, cId.no, '', null, false);
+
+      const storeCall = settingsSharedMocks.storeResponse.mock.calls[0]?.[0];
+      expect(storeCall).toBeDefined();
+      expect(storeCall[cId.physicalCountry]).toBeNull();
+      expect(storeCall[cId.physicalCountry]).not.toBe('');
+    });
+
+    it('sets physicalCountry to null when clearing physical address (id=2)', async () => {
+      installDocumentByIdMap(buildAddressDom(2));
+
+      const userData = buildAddressUserData({ [cId.physicalAddress1]: '789 Pine', [cId.physicalCountry]: 456 });
+      await settingsHelpers.changeMailingAddress(2, '', '', '', '', '', userData, undefined, '', null, false, true);
+
+      const storeCall = settingsSharedMocks.storeResponse.mock.calls[0]?.[0];
+      expect(storeCall).toBeDefined();
+      expect(storeCall[cId.physicalCountry]).toBeNull();
+    });
+
+    it('sets altCountry to null for domestic alt address (id=3)', async () => {
+      installDocumentByIdMap(buildAddressDom(3));
+
+      const userData = buildAddressUserData({ [cId.altAddress1]: '222 Birch', [cId.altCountry]: '' });
+      await settingsHelpers.changeMailingAddress(3, '333 Cedar', '', 'Lakewood', 'CO', '80226', userData, cId.no, '', null, false);
+
+      const storeCall = settingsSharedMocks.storeResponse.mock.calls[0]?.[0];
+      expect(storeCall).toBeDefined();
+      expect(storeCall[cId.altCountry]).toBeNull();
+      expect(storeCall[cId.altCountry]).not.toBe('');
+    });
+
+    it('sets altCountry to parsed integer for international alt address (id=3)', async () => {
+      installDocumentByIdMap(buildAddressDom(3));
+
+      const userData = buildAddressUserData({ [cId.altAddress1]: '222 Birch', [cId.altCountry]: 999, [cId.isIntlAltAddress]: cId.yes });
+      await settingsHelpers.changeMailingAddress(3, '333 Cedar', '', 'Paris', 'IDF', '75001', userData, cId.yes, 'Apt 2', '789', false);
+
+      const storeCall = settingsSharedMocks.storeResponse.mock.calls[0]?.[0];
+      expect(storeCall).toBeDefined();
+      expect(storeCall[cId.altCountry]).toBe(789);
+    });
+  });
 });


### PR DESCRIPTION
Issue Addressed: https://github.com/episphere/connect/issues/1664

This pull request standardizes the handling of country fields for mailing addresses by ensuring that `null` is used instead of empty strings when no country is specified, and that country codes are stored as integers when provided.

**Country field handling improvements:**

* Updated `js/pages/samples.js` to set the `country` parameter to `null` instead of an empty string when submitting a new mailing address.
* Updated `js/settingsHelpers.js` so that the `country`, `physicalCountry`, and `altCountry` fields are set to `null` (not `''`) when not provided, and are parsed as integers for international addresses, or set to `null` if parsing fails. [[1]](diffhunk://#diff-d83a2e12630eb0e1ec99b3a58e65b077e701f34d068b3cd9f5a3b5ee75abb75bL979-R979) [[2]](diffhunk://#diff-d83a2e12630eb0e1ec99b3a58e65b077e701f34d068b3cd9f5a3b5ee75abb75bL992-R992) [[3]](diffhunk://#diff-d83a2e12630eb0e1ec99b3a58e65b077e701f34d068b3cd9f5a3b5ee75abb75bL1011-R1011)