### PR TITLE
toggle self-report functionality from appSettings

### DIFF
--- a/e2e/shareNewHealthInfo/dashboardShareHealthInfo.spec.js
+++ b/e2e/shareNewHealthInfo/dashboardShareHealthInfo.spec.js
@@ -16,6 +16,19 @@ const withoutBannerSeen = (overrides = {}) => {
 };
 
 test.describe('Dashboard — Share New Health Information eligibility and announcement', () => {
+    test('disabled self-report flag hides the card and does not consume the announcement', async ({ page }) => {
+        await setupDashboard(page, {
+            participant: withoutBannerSeen(),
+            i18n: en,
+            selfReportActive: false,
+        });
+
+        await expect(card(page)).toHaveCount(0);
+        await expect(banner(page)).toHaveCount(0);
+        await expect.poll(() => page.evaluate(() => window.__DASHBOARD_DATA__.newHealthInfoBannerSeen)).toBeUndefined();
+        await expect.poll(() => page.evaluate(() => window.__DASHBOARD_STORES__)).not.toContainEqual({ newHealthInfoBannerSeen: true });
+    });
+
     test('verified withdrawn participant sees neither the card nor the announcement', async ({ page }) => {
         await setupDashboard(page, {
             participant: withoutBannerSeen({ [F.consentWithdrawn]: F.yes }),

--- a/e2e/shareNewHealthInfo/dashboardSupport.js
+++ b/e2e/shareNewHealthInfo/dashboardSupport.js
@@ -34,6 +34,12 @@ export const logDDRumError = () => {};
 `;
 
 const moduleStubs = new Map([
+    ['**/js/pages/shareNewHealthInfo/dataAccess.js', `
+        export const loadShareHealthInfoSettings = async () => ({
+            selfReportActive: window.__DASHBOARD_SELF_REPORT_ACTIVE__ === true,
+            enableNPIRegistry: false,
+        });
+    `],
     ['**/js/pages/questionnaire.js', 'export const blockParticipant = () => {};'],
     ['**/js/components/form.js', 'export const renderUserProfile = () => {};'],
     ['**/js/pages/consent.js', 'export const consentTemplate = () => {};'],
@@ -72,22 +78,23 @@ export const dashboardParticipant = (overrides = {}) => ({
     ...overrides,
 });
 
-export const setupDashboard = async (page, { participant, i18n } = {}) => {
+export const setupDashboard = async (page, { participant, i18n, selfReportActive = true } = {}) => {
     await page.route('**/js/shared.js', (route) =>
         route.fulfill({ contentType: 'application/javascript', body: sharedStub }));
     for (const [pattern, body] of moduleStubs) {
         await page.route(pattern, (route) =>
             route.fulfill({ contentType: 'application/javascript', body }));
     }
-    await page.addInitScript(([data, dictionary]) => {
+    await page.addInitScript(([data, dictionary, selfReportEnabled]) => {
         let persisted = {};
         try { persisted = JSON.parse(sessionStorage.getItem('dashboard_seen_flags_e2e') || '{}'); }
         catch (_) { persisted = {}; }
         window.__DASHBOARD_DATA__ = { ...data, ...persisted };
         window.__DASHBOARD_STORES__ = [];
         window.__I18N__ = dictionary || {};
+        window.__DASHBOARD_SELF_REPORT_ACTIVE__ = selfReportEnabled === true;
         window.bootstrap = { Modal: class Modal { show() {} hide() {} } };
-    }, [participant || dashboardParticipant(), i18n || null]);
+    }, [participant || dashboardParticipant(), i18n || null, selfReportActive]);
     await page.goto('/e2e/shareNewHealthInfo/dashboard.harness.html');
     await page.waitForFunction(() => window.__DASHBOARD_RENDERED__ || window.__DASHBOARD_ERROR__);
     const error = await page.evaluate(() => window.__DASHBOARD_ERROR__);

--- a/e2e/shareNewHealthInfo/flow.spec.js
+++ b/e2e/shareNewHealthInfo/flow.spec.js
@@ -145,6 +145,14 @@ test.describe('Share New Health Information — E2E', () => {
         await expect(page.locator('#shareHealthInfoRoot')).toHaveCount(0);
     });
 
+    test('disabled self-report flag blocks direct route access', async ({ page }) => {
+        await setup(page, { selfReportActive: false });
+        await page.waitForFunction(() => window.__SRCDX_RENDERED__ === true || window.__SRCDX_ERROR__);
+        await expect(page.locator('#srcdxAddDiagnosis')).toHaveCount(0);
+        await expect(page.locator('#shareHealthInfoRoot')).toHaveCount(0);
+        await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('#dashboard');
+    });
+
     test('deceased verified participant can access the self-report flow', async ({ page }) => {
         await setup(page, { fixture: deceased });
         await expect(page.locator('#srcdxAddDiagnosis')).toBeVisible();

--- a/e2e/shareNewHealthInfo/landingAndValidation.spec.js
+++ b/e2e/shareNewHealthInfo/landingAndValidation.spec.js
@@ -50,7 +50,6 @@ test.describe('Returning-user landing (previously reported)', () => {
                 export const searchNPIProviders = async () => [];
                 export const saveCancerDxProgress = async () => ({ code: 200 });
                 export const loadCancerDxProgress = async () => null;
-                export const loadShareHealthInfoSettings = async () => ({ enableNPIRegistry: false });
             `,
         });
         await expect(page.locator('#srcdxAddDiagnosis')).toBeVisible(); // graceful: landing renders anyway
@@ -71,7 +70,6 @@ test.describe('Returning-user landing (previously reported)', () => {
                     if (loadAttempts === 1) throw new Error('backend 500');
                     return null;
                 };
-                export const loadShareHealthInfoSettings = async () => ({ enableNPIRegistry: false });
             `,
         });
         await expect(page.locator('#srcdxAddDiagnosis')).toHaveCount(0);

--- a/e2e/shareNewHealthInfo/loops.spec.js
+++ b/e2e/shareNewHealthInfo/loops.spec.js
@@ -422,7 +422,6 @@ test.describe('Loops & repeatable inputs', () => {
                 export const searchNPIProviders = async () => [];
                 export const saveCancerDxProgress = async () => ({ code: 200 });
                 export const loadCancerDxProgress = async () => null;
-                export const loadShareHealthInfoSettings = async () => ({ enableNPIRegistry: false });
             `,
         });
         await page.click('#srcdxAddDiagnosis');

--- a/e2e/shareNewHealthInfo/npiTypeahead.spec.js
+++ b/e2e/shareNewHealthInfo/npiTypeahead.spec.js
@@ -13,8 +13,6 @@ export const submitSelfReportCancerDx = async (payload) => {
 export const getPreviouslyReportedDx = async () => (window.__SRCDX_PRIOR__ || []);
 export const saveCancerDxProgress = async () => ({ code: 200 });
 export const loadCancerDxProgress = async () => null;
-export const loadShareHealthInfoSettings = async () => ({ enableNPIRegistry: true });
-
 const PROVIDERS = [
     { npi: '1234567890', firstName: 'MAYA', lastName: 'SANTOS', credential: 'M.D.', specialty: 'Medical Oncology', city: 'BETHESDA', state: 'MD' },
     { npi: '1098765432', firstName: 'JON', lastName: 'SANTOSO', credential: 'D.O.', specialty: 'Internal Medicine', city: 'ROCKVILLE', state: 'MD' },
@@ -44,7 +42,7 @@ test('NPI feature flag off renders manual physician entry without provider searc
 
 test.describe('NPI provider typeahead', () => {
     test.beforeEach(async ({ page }) => {
-        await setup(page, { dataAccessBody: npiStubBody });
+        await setup(page, { dataAccessBody: npiStubBody, enableNPIRegistry: true });
     });
 
     test('stays closed under 2 characters (no search fired)', async ({ page }) => {

--- a/e2e/shareNewHealthInfo/serverWrites.spec.js
+++ b/e2e/shareNewHealthInfo/serverWrites.spec.js
@@ -42,7 +42,6 @@ export const submitSelfReportCancerDx = async (snapshot) => {
     return { code: 200 };
 };
 export const getPreviouslyReportedDx = async () => [];
-export const loadShareHealthInfoSettings = async () => ({ enableNPIRegistry: false });
 export const searchNPIProviders = async () => [];
 `;
 

--- a/e2e/shareNewHealthInfo/stubs/dataAccess.stub.js
+++ b/e2e/shareNewHealthInfo/stubs/dataAccess.stub.js
@@ -58,10 +58,6 @@ export const submitSelfReportCancerDx = async (snapshot) => {
 
 export const getPreviouslyReportedDx = async () => (window.__SRCDX_PRIOR__ || []);
 
-export const loadShareHealthInfoSettings = async () => ({
-    enableNPIRegistry: window.__SRCDX_ENABLE_NPI_REGISTRY__ === true,
-});
-
 // NPI typeahead transport: default = no matches. Specs that exercise the typeahead pass a
 // custom dataAccessBody with a provider fixture instead.
 export const searchNPIProviders = async () => [];

--- a/e2e/shareNewHealthInfo/support.js
+++ b/e2e/shareNewHealthInfo/support.js
@@ -12,6 +12,14 @@ const dataAccessStub = readFileSync(join(here, 'stubs/dataAccess.stub.js'), 'utf
 
 const withRequiredDataAccessExports = (body) => {
     let next = body;
+    if (!/\bexport\s+const\s+loadShareHealthInfoSettings\b/.test(next)) {
+        next += `
+export const loadShareHealthInfoSettings = async () => ({
+    selfReportActive: window.__SRCDX_SELF_REPORT_ACTIVE__ === true,
+    enableNPIRegistry: window.__SRCDX_ENABLE_NPI_REGISTRY__ === true,
+});
+`;
+    }
     if (!/\bexport\s+const\s+getMostRecentHCSUpdate\b/.test(next)) {
         next += `
 export const getMostRecentHCSUpdate = async () => null;
@@ -57,18 +65,27 @@ export const verified = { code: 200, data: { [F.verification]: F.verified, [F.co
 export const withdrawn = { code: 200, data: { [F.verification]: F.verified, [F.consentWithdrawn]: F.yes, Connect_ID: 'E2E' } };
 export const deceased = { code: 200, data: { [F.verification]: F.verified, [F.consentWithdrawn]: F.no, [F.participantDeceased]: F.yes, Connect_ID: 'E2E' } };
 
-export const setup = async (page, { fixture = verified, prior = [], dataAccessBody = dataAccessStub, i18n = null, enableNPIRegistry = false, hcsLatest = null } = {}) => {
+export const setup = async (page, {
+    fixture = verified,
+    prior = [],
+    dataAccessBody = dataAccessStub,
+    i18n = null,
+    selfReportActive = true,
+    enableNPIRegistry = false,
+    hcsLatest = null,
+} = {}) => {
     await page.route('**/js/shared.js', (route) =>
         route.fulfill({ contentType: 'application/javascript', body: sharedStub }));
     await page.route('**/js/pages/shareNewHealthInfo/dataAccess.js', (route) =>
         route.fulfill({ contentType: 'application/javascript', body: withRequiredDataAccessExports(dataAccessBody) }));
-    await page.addInitScript(([f, p, dict, npiEnabled, hcsRow]) => {
+    await page.addInitScript(([f, p, dict, selfReportEnabled, npiEnabled, hcsRow]) => {
         window.__SRCDX_FIXTURE__ = f;
         window.__SRCDX_PRIOR__ = p;
+        window.__SRCDX_SELF_REPORT_ACTIVE__ = selfReportEnabled === true;
         window.__SRCDX_ENABLE_NPI_REGISTRY__ = npiEnabled === true;
         if (hcsRow) window.__HCS_LATEST__ = hcsRow; // parsed display row for the HCS section
         if (dict) window.__I18N__ = dict; // when provided, the stub translateHTML resolves real labels
-    }, [fixture, prior, i18n, enableNPIRegistry, hcsLatest]);
+    }, [fixture, prior, i18n, selfReportActive, enableNPIRegistry, hcsLatest]);
     await page.goto('/e2e/shareNewHealthInfo/harness.html');
 };
 

--- a/js/pages/dashboard.js
+++ b/js/pages/dashboard.js
@@ -6,6 +6,7 @@ import { addEventHeardAboutStudy, addEventRequestPINForm, addEventHealthCareProv
 import { heardAboutStudy, requestPINTemplate, healthCareProvider, noLongerEnrollingRender } from "./healthCareProvider.js";
 import fieldMapping from '../fieldToConceptIdMapping.js';
 import { isVerifiedNotWithdrawn } from "./shareNewHealthInfo/conditionalLogic.js";
+import { loadShareHealthInfoSettings } from './shareNewHealthInfo/dataAccess.js';
 
 const persistDashboardSeenFlag = (flagName) => {
     const formData = { [flagName]: true };
@@ -229,9 +230,13 @@ export const renderDashboard = async (data, fromUserProfile, collections) => {
                         persistDashboardSeenFlag('updatesSeen');
                 }
 
+                const selfReportActive = isVerifiedNotWithdrawn(data)
+                    ? (await loadShareHealthInfoSettings()).selfReportActive === true
+                    : false;
+
                 // One-time banner announcing the Share New Health Information card (issue #1658, July release).
-                // Shown to verified, not withdrawn participants on their first sign-in after release.
-                if (isVerifiedNotWithdrawn(data) && data['newHealthInfoBannerSeen'] !== true) {
+                // Shown to verified, not withdrawn participants after the runtime feature flag is enabled.
+                if (selfReportActive && data['newHealthInfoBannerSeen'] !== true) {
                     topMessage += `${topMessage.trim() !== '' ? '<br><br>' : ''}
                         <span data-i18n="mytodolist.newHealthInfoBanner">The new <strong>Share New Health Information</strong> card is now on your Dashboard. Here, you can let us know if you change where you get your primary care and share information about a recent cancer diagnosis. In the future, return to this card to check for other options to share information with our team.</span>
                     `;
@@ -263,7 +268,7 @@ export const renderDashboard = async (data, fromUserProfile, collections) => {
                     showSecondaryLoginModal();
                 }
 
-                template += await renderMainBody(data, collections, 'todo');
+                template += await renderMainBody(data, collections, selfReportActive);
                 template += `
                     </div>
                     <div class="col-xl-2">
@@ -425,14 +430,14 @@ const renderWelcomeHeader = (data) => {
     return translateHTML(template);
 }
 
-const renderMainBody = async (data, collections) => {
+const renderMainBody = async (data, collections, selfReportActive) => {
     let template = `<div class="container connect-container">
         <div class="row gy-3">
             ${await renderSurveysCard(data, collections)}
             ${renderSamplesCard(data)}
             ${await renderReportsCard(data)}
             ${renderPaymentCard(data)}
-            ${renderShareHealthInfoCard(data)}
+            ${renderShareHealthInfoCard(data, selfReportActive)}
         </div>
     </div>`;
 
@@ -495,9 +500,10 @@ const renderPaymentCard = (data) => {
     return renderCard(icon, type, href, false);
 }
 
-// "Share New Health Information" card. Shown only to verified, not withdrawn participants (issue #1295).
-const renderShareHealthInfoCard = (data) => {
-    if (!isVerifiedNotWithdrawn(data)) return '';
+// "Share New Health Information" card. Shown only when enabled for a verified,
+// not-withdrawn participant (issue #1295).
+const renderShareHealthInfoCard = (data, selfReportActive) => {
+    if (!selfReportActive || !isVerifiedNotWithdrawn(data)) return '';
     return renderCard('./images/share-health-info-icon.svg', 'shareHealthInfo', '#share-health-info', false);
 }
 

--- a/js/pages/shareNewHealthInfo/dataAccess.js
+++ b/js/pages/shareNewHealthInfo/dataAccess.js
@@ -175,12 +175,22 @@ export const getMostRecentHCSUpdate = async () => {
     return parseHcsRow(submitted[submitted.length - 1]);
 };
 
+/**
+ * Load runtime settings for Share New Health Information.
+ * Feature flags fail closed when the settings document cannot be loaded.
+ */
 export const loadShareHealthInfoSettings = async () => {
     try {
-        const settings = await getAppSettings(['enableNPIRegistry']);
-        return { enableNPIRegistry: settings?.enableNPIRegistry === true };
+        const settings = await getAppSettings(['selfReportActive', 'enableNPIRegistry']);
+        return {
+            selfReportActive: settings?.selfReportActive === true,
+            enableNPIRegistry: settings?.enableNPIRegistry === true,
+        };
     } catch (e) {
-        return { enableNPIRegistry: false };
+        return {
+            selfReportActive: false,
+            enableNPIRegistry: false,
+        };
     }
 };
 

--- a/js/pages/shareNewHealthInfo/hcsSection.js
+++ b/js/pages/shareNewHealthInfo/hcsSection.js
@@ -106,7 +106,7 @@ const initialBodyHtml = (siteName) => `
     ${introHtml()}
     ${currentFacilityHeaderHtml()}
     ${joinedWithHtml(siteName)}
-    <div class="mt-3">${editButtonHtml()}</div>`;
+    <div class="d-flex justify-content-end mt-3">${editButtonHtml()}</div>`;
 
 // 'view', prior update exists: show the latest facility as current and one Edit button for everything.
 const hasAddressDisplayContent = (row) => [

--- a/js/pages/shareNewHealthInfo/index.js
+++ b/js/pages/shareNewHealthInfo/index.js
@@ -61,7 +61,7 @@ let pendingSave = null;
 let reverting = false;
 let savesSuspended = false;
 let inFlightSavePromise = null;
-let featureFlags = { enableNPIRegistry: false };
+let featureFlags = { selfReportActive: false, enableNPIRegistry: false };
 let saveGeneration = 0;
 
 const teardownScreenEventSources = () => {
@@ -84,7 +84,7 @@ const resetRuntime = ({ clearParticipant = false } = {}) => {
     hasServerRow = false;
     reverting = false;
     savesSuspended = false;
-    featureFlags = { enableNPIRegistry: false };
+    featureFlags = { selfReportActive: false, enableNPIRegistry: false };
     state.resetState();
     discardEditSnapshot();
     resetConfirmState();
@@ -366,9 +366,16 @@ export const renderShareNewHealthInfo = async (dataResponse) => {
         return;
     }
 
+    featureFlags = await loadShareHealthInfoSettings();
+    if (featureFlags.selfReportActive !== true) {
+        resetRuntime();
+        window.location.hash = '#dashboard';
+        hideAnimation();
+        return;
+    }
+
     content = mountContainer();
     savesSuspended = false;
-    featureFlags = await loadShareHealthInfoSettings();
 
     let saved = null;
     try {

--- a/tests/hcsSection.spec.js
+++ b/tests/hcsSection.spec.js
@@ -85,7 +85,10 @@ describe('initial view (no prior update)', () => {
         expect(content.textContent).toContain('Sanford Health');
         expect(content.querySelector('.srcdx-hcs-facility-name').textContent).toBe('Sanford Health');
         expect(content.querySelector('.srcdx-hcs-facility-name').tagName).toBe('STRONG');
-        expect(content.querySelector('#srcdxHcsUpdate').textContent).toBe('Edit');
+        const editButton = content.querySelector('#srcdxHcsUpdate');
+        expect(editButton.textContent).toBe('Edit');
+        expect(editButton.parentElement.classList.contains('d-flex')).toBe(true);
+        expect(editButton.parentElement.classList.contains('justify-content-end')).toBe(true);
         expect(content.querySelector('[data-srcdxhcs-card]').classList.contains('srcdx-collapsed')).toBe(false);
         // No address form or facility display in the resting view.
         expect(content.querySelector('#UPAddressHcsFacLine1')).toBeNull();

--- a/tests/srcDxDashboard.spec.js
+++ b/tests/srcDxDashboard.spec.js
@@ -4,6 +4,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { JSDOM } from 'jsdom';
 
+const settingsMocks = vi.hoisted(() => ({
+    loadShareHealthInfoSettings: vi.fn(),
+}));
+
 vi.mock('../js/shared.js', () => ({
     hideAnimation: vi.fn(),
     questionnaireModules: vi.fn(() => ({})),
@@ -36,6 +40,9 @@ vi.mock('../js/pages/healthCareProvider.js', () => ({
     requestPINTemplate: vi.fn(() => ''),
     healthCareProvider: vi.fn(() => ''),
     noLongerEnrollingRender: vi.fn(),
+}));
+vi.mock('../js/pages/shareNewHealthInfo/dataAccess.js', () => ({
+    loadShareHealthInfoSettings: settingsMocks.loadShareHealthInfoSettings,
 }));
 
 import * as shared from '../js/shared.js';
@@ -73,6 +80,10 @@ beforeEach(() => {
     globalThis.sessionStorage = dom.window.sessionStorage;
     globalThis.bootstrap = { Modal: function Modal() { this.show = vi.fn(); this.hide = vi.fn(); } };
     vi.clearAllMocks();
+    settingsMocks.loadShareHealthInfoSettings.mockResolvedValue({
+        selfReportActive: true,
+        enableNPIRegistry: false,
+    });
 });
 
 describe('dashboard Share New Health Information card', () => {
@@ -107,6 +118,16 @@ describe('dashboard Share New Health Information card', () => {
             expect(root.querySelector('#shareHealthInfoCard')).toBeNull();
         }
     });
+
+    it('does not render when self-report is disabled', async () => {
+        settingsMocks.loadShareHealthInfoSettings.mockResolvedValue({
+            selfReportActive: false,
+            enableNPIRegistry: false,
+        });
+
+        const root = await render(baseData());
+        expect(root.querySelector('#shareHealthInfoCard')).toBeNull();
+    });
 });
 
 describe('dashboard Share New Health Information one-time banner (issue #1658)', () => {
@@ -129,6 +150,19 @@ describe('dashboard Share New Health Information one-time banner (issue #1658)',
     it('does not show the banner to withdrawn participants', async () => {
         const data = baseData({ [fieldMapping.consentWithdrawn]: fieldMapping.yes });
         delete data.newHealthInfoBannerSeen;
+        const root = await render(data);
+        expect(root.querySelector('[data-i18n="mytodolist.newHealthInfoBanner"]')).toBeNull();
+        expect(shared.storeResponse).not.toHaveBeenCalledWith({ newHealthInfoBannerSeen: true });
+    });
+
+    it('does not show or consume the banner while self-report is disabled', async () => {
+        settingsMocks.loadShareHealthInfoSettings.mockResolvedValue({
+            selfReportActive: false,
+            enableNPIRegistry: false,
+        });
+        const data = baseData();
+        delete data.newHealthInfoBannerSeen;
+
         const root = await render(data);
         expect(root.querySelector('[data-i18n="mytodolist.newHealthInfoBanner"]')).toBeNull();
         expect(shared.storeResponse).not.toHaveBeenCalledWith({ newHealthInfoBannerSeen: true });

--- a/tests/srcDxDataAccess.spec.js
+++ b/tests/srcDxDataAccess.spec.js
@@ -9,7 +9,7 @@ vi.mock('../js/shared.js', () => ({
     appState: { getState: () => ({ idToken: 'tok' }) },
     getIdToken: async () => 'tok',
     getApiBaseUrl: () => 'https://cf.test/app',
-    getAppSettings: vi.fn(async () => ({ enableNPIRegistry: false })),
+    getAppSettings: vi.fn(async () => ({ selfReportActive: false, enableNPIRegistry: false })),
     translateText: (k) => k, // labels assert on the i18n KEY
     allCountries: { 'United States': 1, 'United Kingdom': 2 }, // payload.js -> countryCid.js dependency
 }));
@@ -27,7 +27,10 @@ beforeEach(() => {
     fetchStub = vi.fn(async () => jsonResponse({ code: 200 }));
     vi.stubGlobal('fetch', fetchStub);
     vi.stubGlobal('location', { hostname: 'app.test' });
-    vi.mocked(getAppSettings).mockReset().mockResolvedValue({ enableNPIRegistry: false });
+    vi.mocked(getAppSettings).mockReset().mockResolvedValue({
+        selfReportActive: false,
+        enableNPIRegistry: false,
+    });
 });
 
 afterEach(() => {
@@ -139,26 +142,54 @@ describe('getPreviouslyReportedDx', () => {
 });
 
 describe('loadShareHealthInfoSettings', () => {
-    it('enables NPI registry only for strict boolean true', async () => {
-        vi.mocked(getAppSettings).mockResolvedValue({ enableNPIRegistry: true });
+    it('enables each feature only for strict boolean true', async () => {
+        vi.mocked(getAppSettings).mockResolvedValue({
+            selfReportActive: true,
+            enableNPIRegistry: true,
+        });
         const { loadShareHealthInfoSettings } = await importDataAccess();
-        expect(await loadShareHealthInfoSettings()).toEqual({ enableNPIRegistry: true });
-        expect(getAppSettings).toHaveBeenCalledWith(['enableNPIRegistry']);
+
+        await expect(loadShareHealthInfoSettings()).resolves.toEqual({
+            selfReportActive: true,
+            enableNPIRegistry: true,
+        });
+        expect(getAppSettings).toHaveBeenCalledWith(['selfReportActive', 'enableNPIRegistry']);
     });
 
     it.each([
-        ['false', { enableNPIRegistry: false }],
-        ['missing', {}],
-        ['string true', { enableNPIRegistry: 'true' }],
-    ])('keeps NPI registry disabled for %s', async (_label, settings) => {
+        ['false values', { selfReportActive: false, enableNPIRegistry: false }],
+        ['missing values', {}],
+        ['string values', { selfReportActive: 'true', enableNPIRegistry: 'true' }],
+    ])('keeps both features disabled for %s', async (_label, settings) => {
         vi.mocked(getAppSettings).mockResolvedValue(settings);
         const { loadShareHealthInfoSettings } = await importDataAccess();
-        expect(await loadShareHealthInfoSettings()).toEqual({ enableNPIRegistry: false });
+
+        await expect(loadShareHealthInfoSettings()).resolves.toEqual({
+            selfReportActive: false,
+            enableNPIRegistry: false,
+        });
     });
 
-    it('defaults NPI registry off if appSettings cannot be loaded', async () => {
+    it('preserves independent settings', async () => {
+        vi.mocked(getAppSettings).mockResolvedValue({
+            selfReportActive: false,
+            enableNPIRegistry: true,
+        });
+        const { loadShareHealthInfoSettings } = await importDataAccess();
+
+        await expect(loadShareHealthInfoSettings()).resolves.toEqual({
+            selfReportActive: false,
+            enableNPIRegistry: true,
+        });
+    });
+
+    it('fails closed if appSettings cannot be loaded', async () => {
         vi.mocked(getAppSettings).mockRejectedValue(new Error('down'));
         const { loadShareHealthInfoSettings } = await importDataAccess();
-        expect(await loadShareHealthInfoSettings()).toEqual({ enableNPIRegistry: false });
+
+        await expect(loadShareHealthInfoSettings()).resolves.toEqual({
+            selfReportActive: false,
+            enableNPIRegistry: false,
+        });
     });
 });


### PR DESCRIPTION
Related:
https://github.com/episphere/connect/issues/1295
https://github.com/episphere/connect/issues/1658

Use Firestore appSettings configs to toggle self-report functionality active/inactive as needed.